### PR TITLE
feat(theme/nord): add favourite and bookmark icon

### DIFF
--- a/mastodon/src/main/res/color/bookmark_icon.xml
+++ b/mastodon/src/main/res/color/bookmark_icon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-	<item android:color="@color/bookmark_selected" android:state_selected="true"/>
+	<item android:color="?bookmark_selected" android:state_selected="true"/>
 	<item android:color="?android:textColorSecondary"/>
 </selector>

--- a/mastodon/src/main/res/color/favorite_icon.xml
+++ b/mastodon/src/main/res/color/favorite_icon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-	<item android:color="@color/favorite_selected" android:state_selected="true"/>
+	<item android:color="?favorite_selected" android:state_selected="true"/>
 	<item android:color="?android:textColorSecondary"/>
 </selector>

--- a/mastodon/src/main/res/values/attrs.xml
+++ b/mastodon/src/main/res/values/attrs.xml
@@ -16,6 +16,8 @@
 	<attr name="colorSearchHint" format="color"/>
 	<attr name="colorTabInactive" format="color"/>
 	<attr name="colorAccentLightest" format="color"/>
+	<attr name="favorite_selected" format="color"/>
+	<attr name="bookmark_selected" format="color"/>
 	<attr name="profileHeaderBackground" format="color"/>
 	<attr name="toolbarBackground" format="color"/>
 

--- a/mastodon/src/main/res/values/colors.xml
+++ b/mastodon/src/main/res/values/colors.xml
@@ -312,6 +312,9 @@
 	<color name="nord_gray_600">#404C5C</color>
 	<color name="nord_gray_500">#8C96B4</color>
 
+	<color name="nord_favorite_selected">#ebcb8b</color>
+	<color name="nord_bookmark_selected">#a3be8c</color>
+
 	<color name="nord_gray_400">#8C96B4</color>
 	<color name="nord_gray_300">#c5c6d0</color>
 	<color name="nord_gray_200">#D5DCE6</color>

--- a/mastodon/src/main/res/values/palettes.xml
+++ b/mastodon/src/main/res/values/palettes.xml
@@ -12,6 +12,8 @@
 		<item name="colorPrimary700">@color/primary_700</item>
 		<item name="colorPrimary800">@color/primary_800</item>
 		<item name="colorPrimary900">@color/primary_900</item>
+		<item name="bookmark_selected">@color/bookmark_selected</item>
+		<item name="favorite_selected">@color/favorite_selected</item>
 
 		<item name="colorGray900">@color/gray_900</item>
 		<item name="colorGray800t">@color/gray_800t</item>
@@ -245,6 +247,9 @@
 		<item name="colorPrimary700">@color/nord_primary_700</item>
 		<item name="colorPrimary800">@color/nord_primary_800</item>
 		<item name="colorPrimary900">@color/nord_primary_900</item>
+
+		<item name="bookmark_selected">@color/nord_bookmark_selected</item>
+		<item name="favorite_selected">@color/nord_favorite_selected</item>
 
 		<item name="colorGray900">@color/nord_gray_900</item>
 		<item name="colorGray800t">@color/nord_gray_800t</item>


### PR DESCRIPTION
Changes the selected favorite and bookmark icon color to be depended on the current theme. This is only implemented in this pr for the nord theme, but can be also done for the other themes (e.g. Material you would be a prime candidate).

I think it is worthwhile implementing this now, as it can be used for future themes with custom colors.

| Before                                                                                                           | After                                                                                                           |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/63370021/209437308-f3d76114-8ca0-49b6-aa56-a6f43ada464d.png) | ![After](https://user-images.githubusercontent.com/63370021/209437307-bee41b07-8c16-4c18-b43e-c68b916d3b01.png) |