### PR TITLE
feat(compose/publish): Add warning dialog when no image description is provided

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -131,6 +131,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -917,7 +918,18 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 	}
 
 	private void onPublishClick(View v){
-		publish();
+		if (!attachments.isEmpty()
+				&& statusVisibility != StatusPrivacy.DIRECT
+				&& !attachments.stream().allMatch(attachment -> attachment.description != null && !attachment.description.isBlank())) {
+			new M3AlertDialogBuilder(getActivity())
+					.setTitle(R.string.sk_no_image_desc_title)
+					.setMessage(R.string.sk_no_image_desc)
+					.setNegativeButton(R.string.cancel, null)
+					.setPositiveButton(R.string.publish, (dialog, i)-> publish())
+					.show();
+		} else {
+			publish();
+		}
 	}
 
 	private void publishErrorCallback(ErrorResponse error) {
@@ -1029,6 +1041,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 				publishErrorCallback(error);
 			}
 		};
+
 
 		if(editingStatus!=null && !redraftStatus){
 			new EditStatus(req, editingStatus.id)

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -131,7 +131,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -131,4 +131,6 @@
     <string name="sk_compose_no_draft">Don’t draft</string>
     <string name="sk_settings_reduce_motion">Reduce motion in animations</string>
     <string name="sk_bot_account">This is a bot account</string>
+    <string name="sk_no_image_desc_title">No Image description</string>
+    <string name="sk_no_image_desc">The included images have no description. Please consider adding one, to allow visually impaired people to participate.</string>
 </resources>


### PR DESCRIPTION
Adds a warning dialog when publicly posting images that have no description. The user still has the choice to publish anyway, or to chancel. 
Some instance, [for example floss.social](https://floss.social/@admin/109451240614809749), already require all public post to include image descriptions.
![Warning dialog](https://user-images.githubusercontent.com/63370021/210228428-243a4e33-1560-4f21-8a41-74dfc3c652a5.png)
