### PR TITLE
feat: share links

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/LinkSpan.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/LinkSpan.java
@@ -1,8 +1,10 @@
 package org.joinmastodon.android.ui.text;
 
 import android.content.Context;
+import android.content.Intent;
 import android.text.TextPaint;
 import android.text.style.CharacterStyle;
+import android.util.Log;
 import android.view.View;
 
 import org.joinmastodon.android.ui.utils.UiUtils;
@@ -42,7 +44,14 @@ public class LinkSpan extends CharacterStyle {
 	}
 
 	public void onLongClick(View view) {
-		UiUtils.copyText(view, getType() == Type.URL ? link : text);
+		if (getType() == Type.URL) {
+            Intent shareIntent = new Intent(Intent.ACTION_SEND)
+                    .setType("text/plain")
+                    .putExtra(Intent.EXTRA_TEXT, link);
+			view.getContext().startActivity(Intent.createChooser(shareIntent, null));
+		} else {
+			UiUtils.copyText(view, text);
+		}
 	}
 
 	public String getLink(){


### PR DESCRIPTION
Instead of copying the link URL when long pressing, the Sharesheet is shown. This still retains the old functionality, since by default the Sharesheet has the options to copy the link.
![Example share](https://user-images.githubusercontent.com/63370021/210639863-46d42a29-1506-4eeb-b927-91cce41b6a9e.gif)

### Disadvantages
Some OEMs may have changed the Sharesheet and disabled the `copy` button. The one example I know of, is Huawei with EMUI, which does not have a `copy` button. But I still think it is worth merging, since the most likely use case after copying the URL is to paste it in another app, which can also be done via sharing it.