### PR TITLE
fix(status/favouriteIcon): disable animation when interaction count i…

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
@@ -310,7 +310,7 @@ public class FooterStatusDisplayItem extends StatusDisplayItem{
 		private void onFavoriteClick(View v){
 			favorite.setSelected(!item.status.favourited);
 			AccountSessionManager.getInstance().getAccount(item.accountID).getStatusInteractionController().setFavorited(item.status, !item.status.favourited, r->{
-				if (item.status.favourited) {
+				if (item.status.favourited && !GlobalUserPreferences.showInteractionCounts) {
 					v.startAnimation(animSet);
 				} else {
 					v.startAnimation(opacityIn);


### PR DESCRIPTION
…s shown

Disables the favourite spinning animation when the `showInteractionCounts` setting is enabled. This fixes a bug, where the updated interaction count text would also spin.

https://user-images.githubusercontent.com/63370021/210879892-f20e8e31-d4aa-42a4-a25b-a11baab5b4f8.mp4

### Alternative solutions
As an alternative, the icon could be split from the interaction counter, which would allow it to animate the icon only, but it would require to have a unified click listener on both, the icon and the text.