### PR TITLE
feat(compose): move charCounter to action bar if relocatePublishButto…

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -307,12 +307,14 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 
 			draftsBtn=view.findViewById(R.id.drafts_btn);
 			draftsBtn.setVisibility(View.VISIBLE);
+		} else {
+			charCounter=view.findViewById(R.id.char_counter);
+			charCounter.setVisibility(View.VISIBLE);
+			charCounter.setText(String.valueOf(charLimit));
 		}
 
 		mainEditText=view.findViewById(R.id.toot_text);
 		mainEditTextWrap=view.findViewById(R.id.toot_text_wrap);
-		charCounter=view.findViewById(R.id.char_counter);
-		charCounter.setText(String.valueOf(charLimit));
 		scrollView=view.findViewById(R.id.scroll_view);
 
 		selfName=view.findViewById(R.id.self_name);
@@ -748,6 +750,10 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 
 			draftsBtn = wrap.findViewById(R.id.drafts_btn);
 			draftsBtn.setVisibility(View.VISIBLE);
+		}else{
+			charCounter = wrap.findViewById(R.id.char_counter);
+			charCounter.setVisibility(View.VISIBLE);
+			charCounter.setText(String.valueOf(charLimit));
 		}
 
 //		draftsBtn = wrap.findViewById(R.id.drafts_btn);

--- a/mastodon/src/main/res/layout/compose_action.xml
+++ b/mastodon/src/main/res/layout/compose_action.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
@@ -53,6 +54,15 @@
         android:visibility="gone"
         android:contentDescription="@string/sk_schedule_or_draft"
         android:tooltipText="@string/sk_schedule_or_draft" />
+
+    <TextView
+        android:id="@+id/char_counter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/m3_body_large"
+        android:textColor="?android:textColorSecondary"
+        android:visibility="gone"
+        tools:text="500"/>
 
     <Button
         android:id="@+id/publish_btn"

--- a/mastodon/src/main/res/layout/fragment_compose.xml
+++ b/mastodon/src/main/res/layout/fragment_compose.xml
@@ -422,6 +422,7 @@
 				android:layout_height="wrap_content"
 				android:textAppearance="@style/m3_body_large"
 				android:textColor="?android:textColorSecondary"
+				android:visibility="gone"
 				tools:text="500"/>
 
 			<Button


### PR DESCRIPTION
…n is enabled

Basically, it swaps the `charCounter` and the `publishButton` if `relocatePublishButton` is enabled. This gives the bottom elements more space, and does not change the UX, since the counter is only a visual element and does not have a click function. Fixes https://github.com/sk22/megalodon/issues/243.

| Disabled                                                                                                                                 | Enabled                                                                                                                                 | Before                                                                                                           |
|------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
| ![relocatePublishButton Disabled](https://user-images.githubusercontent.com/63370021/211582264-6debe82b-6f8a-4df8-bec5-5a07bc91d46e.png) | ![relocatePublishButton enabled](https://user-images.githubusercontent.com/63370021/211582284-d53ef146-f9c2-4929-aa6e-460f3d69fa7d.png) | ![Before](https://user-images.githubusercontent.com/63370021/211583011-686abc35-5236-48c5-add6-999b1dcabb4d.png) |
