### PR TITLE
feat(profile): move options to overflow menu

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -643,7 +643,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			return;
 		inflater.inflate(isOwnProfile ? R.menu.profile_own : R.menu.profile, menu);
 		if(isOwnProfile){
-			UiUtils.enableOptionsMenuIcons(getActivity(), menu, R.id.manage_user_lists, R.id.bookmarks, R.id.followed_hashtags, R.id.favorites, R.id.scheduled, R.id.share);
+			UiUtils.enableOptionsMenuIcons(getActivity(), menu, R.id.scheduled, R.id.bookmarks, R.id.favorites);
 		}else{
 			UiUtils.enableOptionsMenuIcons(getActivity(), menu, R.id.bookmarks, R.id.followed_hashtags, R.id.favorites, R.id.scheduled);
 		}

--- a/mastodon/src/main/res/menu/profile_own.xml
+++ b/mastodon/src/main/res/menu/profile_own.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-	<item android:id="@+id/followed_hashtags" android:title="@string/sk_hashtags_you_follow" android:icon="@drawable/ic_fluent_number_symbol_24_regular" android:showAsAction="always"/>
-	<item android:id="@+id/manage_user_lists" android:title="@string/sk_your_lists" android:icon="@drawable/ic_fluent_people_list_24_regular" android:showAsAction="always"/>
+	<item android:id="@+id/followed_hashtags" android:title="@string/sk_hashtags_you_follow" android:icon="@drawable/ic_fluent_number_symbol_24_regular" />
+	<item android:id="@+id/manage_user_lists" android:title="@string/sk_your_lists" android:icon="@drawable/ic_fluent_people_list_24_regular" />
 	<item android:id="@+id/bookmarks" android:title="@string/bookmarks" android:icon="@drawable/ic_fluent_bookmark_multiple_24_regular" android:showAsAction="always"/>
 	<item android:id="@+id/favorites" android:title="@string/your_favorites" android:icon="@drawable/ic_fluent_star_24_regular" android:showAsAction="always"/>
 	<item android:id="@+id/scheduled" android:title="@string/sk_unsent_posts" android:icon="@drawable/ic_fluent_drafts_24_regular" android:showAsAction="always"/>
-	<item android:id="@+id/share" android:title="@string/share_user" android:icon="@drawable/ic_fluent_share_24_regular" android:showAsAction="always"/>
+	<item android:id="@+id/share" android:title="@string/share_user" android:icon="@drawable/ic_fluent_share_24_regular" />
 </menu>


### PR DESCRIPTION
This moves some of the icons into an overflow menu. This is necessary, as currently up to six icons will be displayed (according to the [Material Guidelines](https://m3.material.io/components/top-app-bar/guidelines#b1b64842-7d88-4c3f-8ffb-4183fe648c9e) only three should be displayed and less important ones moved to an overflow menu), causing layout issues, as can be seen in the Before example screenshot. The layout problem is worsened on smaller phones and for users with longer names. 
The moved options are rarely used, or in the case of the `Followed Hashtags` options even redundant, as the same functionality is provided by the new timeline layout. 
| Before                                                                                                           | After                                                                                                           |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/63370021/214393147-e987cdb6-ac75-4618-8e44-8a107bc472c6.png) | ![After](https://user-images.githubusercontent.com/63370021/214393142-e4ec84a7-1919-4aae-971a-2a1e36280192.png) |