### PR TITLE
fix(compose): remove marginEnd

### DIFF
--- a/mastodon/src/main/res/layout/fragment_compose.xml
+++ b/mastodon/src/main/res/layout/fragment_compose.xml
@@ -277,7 +277,6 @@
 		android:elevation="2dp"
 		android:outlineProvider="bounds"
 		android:paddingHorizontal="10dp"
-		android:layout_marginEnd="6dp"
 		android:layoutDirection="locale">
 		<LinearLayout
 			android:id="@+id/schedule_draft_view"


### PR DESCRIPTION
Fixes an issue with the margin in the compose UI by removing it. Notice how the small gray strip (it's more noticeable on a device) is gone.

| Before                                                                                                           	| After                                                                                                           	|
|------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
| ![Before](https://user-images.githubusercontent.com/63370021/216839159-2b0ee57e-8dc1-49f0-8db2-dfbbfd84ca6c.png) 	| ![After](https://user-images.githubusercontent.com/63370021/216839150-4d7e43d9-17a8-461a-8da3-1ce6d85aa74a.png) 	|
