### PR TITLE
fix(star-animation): re-enable star animation

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
@@ -312,11 +312,7 @@ public class FooterStatusDisplayItem extends StatusDisplayItem{
 			favorite.setSelected(!item.status.favourited);
 			AccountSessionManager.getInstance().getAccount(item.accountID).getStatusInteractionController().setFavorited(item.status, !item.status.favourited, r->{
 				if (item.status.favourited) {
-//					if(GlobalUserPreferences.reduceMotion){
-					v.startAnimation(opacityIn);
-//					}else{
-//						v.startAnimation(animSet);
-//					}
+						v.startAnimation(GlobalUserPreferences.reduceMotion ? opacityIn : animSet);
 				} else {
 					v.startAnimation(opacityIn);
 				}

--- a/mastodon/src/main/res/layout/display_item_footer.xml
+++ b/mastodon/src/main/res/layout/display_item_footer.xml
@@ -64,7 +64,7 @@
 			android:id="@+id/favorite"
 			android:layout_width="wrap_content"
 			android:layout_height="match_parent"
-			android:layout_gravity="center_vertical"
+			android:layout_gravity="center"
 			android:drawableStart="@drawable/ic_fluent_star_24_selector"
 			android:drawablePadding="8dp"
 			android:paddingHorizontal="8dp"


### PR DESCRIPTION
Fixes and re-enables the star animation, which was broken by https://github.com/LucasGGamerM/moshidon/commit/31d0bfb43423de98770bea936ed65856d123626e and disabled in https://github.com/LucasGGamerM/moshidon/commit/2b7f3253325c1379ec97b071530d9ea26c0eb39c. Please notice that I have no idea what the result of changed code was, so it's quite possible, that it broke something else, which I didn't notice.