### PR TITLE
fix(custom-timelines): remove default text

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -150,7 +150,6 @@ public class EditTimelinesFragment extends BaseRecyclerFragment<TimelineDefiniti
         FrameLayout inputWrap = new FrameLayout(getContext());
         EditText input = new EditText(getContext());
         input.setHint(R.string.sk_example_domain);
-        input.setText(GlobalUserPreferences.publishButtonText.trim());
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         params.setMargins(V.dp(16), V.dp(4), V.dp(16), V.dp(16));
         input.setLayoutParams(params);


### PR DESCRIPTION
By default, the Timeline URL input field show the text of the publish button, which this pr removes-


| Before                                                                                                           	| After                                                                                                           	|
|------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
| ![Before](https://user-images.githubusercontent.com/63370021/220170311-6e4515c0-86db-46d0-8523-53af2d45b481.png) 	| ![After](https://user-images.githubusercontent.com/63370021/220170301-e09ffa1b-44f4-4eef-af35-cab61b3df49b.png) 	|