### PR TITLE
feat(custom-timelines): use URI InputType

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -7,6 +7,7 @@ import static org.joinmastodon.android.ui.utils.UiUtils.makeBackItem;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -150,6 +151,7 @@ public class EditTimelinesFragment extends BaseRecyclerFragment<TimelineDefiniti
         FrameLayout inputWrap = new FrameLayout(getContext());
         EditText input = new EditText(getContext());
         input.setHint(R.string.sk_example_domain);
+        input.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         params.setMargins(V.dp(16), V.dp(4), V.dp(16), V.dp(16));
         input.setLayoutParams(params);


### PR DESCRIPTION
Sets the `InputType` of the custom timeline URL edittext to `TYPE_TEXT_VARIATION_URI`, which makes it easier to enter URLs, by adding dedicated keys for top level domains and turning off some parts of AutoCorrect, like auto-placing a space after a dot. 

![URL Input help](https://user-images.githubusercontent.com/63370021/220199138-aac79221-5c68-49db-9421-8325ce1c5c70.png)
