### PR TITLE
Feat: Add actions to notifications

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
@@ -107,26 +107,6 @@ public class MainActivity extends FragmentStackActivity{
 			}
 		}else if(intent.getBooleanExtra("compose", false)){
 			showCompose();
-		}else if(intent.getStringExtra("notificationAction") != null) {
-			switch (NotificationAction.values()[intent.getIntExtra("notificationAction", 0)]) {
-				case FAVORITE -> {
-					String accountID=intent.getStringExtra("accountID");
-					new SetStatusFavorited(intent.getStringExtra("status"), true)
-							.setCallback(new Callback<>(){
-								@Override
-								public void onSuccess(Status result){
-								}
-
-								@Override
-								public void onError(ErrorResponse error){
-								}
-							})
-							.exec(accountID);
-				}
-				case REBLOG -> {
-				}
-			}
-
 		}/*else if(intent.hasExtra(PackageInstaller.EXTRA_STATUS) && GithubSelfUpdater.needSelfUpdating()){
 			GithubSelfUpdater.getInstance().handleIntentFromInstaller(intent, this);
 		}*/

--- a/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
@@ -7,10 +7,14 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.Toast;
 
 import org.joinmastodon.android.api.ObjectValidationException;
+import org.joinmastodon.android.api.requests.accounts.SetPrivateNote;
+import org.joinmastodon.android.api.requests.statuses.SetStatusFavorited;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
+import org.joinmastodon.android.events.StatusCountersUpdatedEvent;
 import org.joinmastodon.android.fragments.ComposeFragment;
 import org.joinmastodon.android.fragments.HomeFragment;
 import org.joinmastodon.android.fragments.ProfileFragment;
@@ -19,12 +23,17 @@ import org.joinmastodon.android.fragments.onboarding.AccountActivationFragment;
 import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
 import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
 import org.joinmastodon.android.model.Notification;
+import org.joinmastodon.android.model.NotificationAction;
+import org.joinmastodon.android.model.Relationship;
+import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.updater.GithubSelfUpdater;
 import org.parceler.Parcels;
 
 import androidx.annotation.Nullable;
 import me.grishka.appkit.FragmentStackActivity;
+import me.grishka.appkit.api.Callback;
+import me.grishka.appkit.api.ErrorResponse;
 
 public class MainActivity extends FragmentStackActivity{
 	@Override
@@ -98,6 +107,26 @@ public class MainActivity extends FragmentStackActivity{
 			}
 		}else if(intent.getBooleanExtra("compose", false)){
 			showCompose();
+		}else if(intent.getStringExtra("notificationAction") != null) {
+			switch (NotificationAction.values()[intent.getIntExtra("notificationAction", 0)]) {
+				case FAVORITE -> {
+					String accountID=intent.getStringExtra("accountID");
+					new SetStatusFavorited(intent.getStringExtra("status"), true)
+							.setCallback(new Callback<>(){
+								@Override
+								public void onSuccess(Status result){
+								}
+
+								@Override
+								public void onError(ErrorResponse error){
+								}
+							})
+							.exec(accountID);
+				}
+				case REBLOG -> {
+				}
+			}
+
 		}/*else if(intent.hasExtra(PackageInstaller.EXTRA_STATUS) && GithubSelfUpdater.needSelfUpdating()){
 			GithubSelfUpdater.getInstance().handleIntentFromInstaller(intent, this);
 		}*/

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -99,11 +99,11 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 				Log.w(TAG, "onReceive: invalid push notification format");
 			}
 		}
-		if(intent.getBooleanExtra("fromNotificationAction", false)) {
+		if(intent.getBooleanExtra("fromNotificationAction", false)){
 			String accountID=intent.getStringExtra("accountID");
 			int notificationId=intent.getIntExtra("notificationId", -1);
 
-			if ( notificationId >= 0) {
+			if (notificationId >= 0){
 				NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 				notificationManager.cancel(accountID, notificationId);
 			}
@@ -123,7 +123,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 						default -> Log.w(TAG, "onReceive: Failed to get NotificationAction");
 					}
 				}
-			} else {
+			}else{
 				Log.e(TAG, "onReceive: Failed to load notification");
 			}
 		}
@@ -203,8 +203,8 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 
 		int id = GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++;
 
-		if (notification != null) {
-			switch (pn.notificationType) {
+		if (notification != null){
+			switch (pn.notificationType){
 				case MENTION, STATUS -> {
 					builder.addAction(buildNotificationAction(context, id, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
 					builder.addAction(buildNotificationAction(context, id, accountID, notification, context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
@@ -228,8 +228,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		notificationIntent.putExtra("accountID", accountID);
 		notificationIntent.putExtra("notificationAction", action.ordinal());
 		notificationIntent.putExtra("notification", Parcels.wrap(notification));
-		PendingIntent actionPendingIntent =
-				PendingIntent.getBroadcast(context, new Random().nextInt(), notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_ONE_SHOT);
+		PendingIntent actionPendingIntent = PendingIntent.getBroadcast(context, new Random().nextInt(), notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_ONE_SHOT);
 
 		return new Notification.Action.Builder(null, title, actionPendingIntent).build();
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -201,8 +201,8 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 
 		switch (pn.notificationType) {
 			case MENTION -> {
-				builder.addAction(buildNotificationAction(context, accountID, notification,  "Favourite", NotificationAction.FAVORITE));
-				builder.addAction(buildNotificationAction(context, accountID, notification,  "Bookmark", NotificationAction.BOOKMARK));
+				builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
+				builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
 				if (notification != null && notification.status.visibility != StatusPrivacy.DIRECT)
 					builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.REBLOG));
 			}

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -9,6 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -16,10 +17,15 @@ import android.util.Log;
 
 import org.joinmastodon.android.api.MastodonAPIController;
 import org.joinmastodon.android.api.requests.notifications.GetNotificationByID;
+import org.joinmastodon.android.api.requests.statuses.SetStatusBookmarked;
+import org.joinmastodon.android.api.requests.statuses.SetStatusFavorited;
+import org.joinmastodon.android.api.requests.statuses.SetStatusReblogged;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.model.NotificationAction;
 import org.joinmastodon.android.model.PushNotification;
+import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.parceler.Parcels;
 
@@ -27,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import me.grishka.appkit.api.APIRequest;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
 import me.grishka.appkit.imageloader.ImageCache;
@@ -90,6 +97,25 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 				});
 			}else{
 				Log.w(TAG, "onReceive: invalid push notification format");
+			}
+		}
+		if(intent.getBooleanExtra("fromNotificationAction", false)) {
+			String accountID=intent.getStringExtra("accountID");
+
+			if(intent.hasExtra("notification")){
+				org.joinmastodon.android.model.Notification notification=Parcels.unwrap(intent.getParcelableExtra("notification"));
+				String statusID=notification.status.id;
+				if (statusID != null) {
+
+					switch (NotificationAction.values()[intent.getIntExtra("notificationAction", 0)]) {
+						case FAVORITE -> new SetStatusFavorited(statusID, true).exec(accountID);
+						case BOOKMARK -> new SetStatusBookmarked(statusID, true).exec(accountID);
+//						case REBLOG -> new SetStatusReblogged(notification.status.id, true, GlobalUserPreferences.);
+						default -> Log.w(TAG, "onReceive: Failed to get NotificationAction");
+					}
+				}
+			} else {
+				Log.e(TAG, "onReceive: Failed to load notification");
 			}
 		}
 	}
@@ -165,6 +191,31 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		if(AccountSessionManager.getInstance().getLoggedInAccounts().size()>1){
 			builder.setSubText(accountName);
 		}
+
+
+		switch (pn.notificationType) {
+			case MENTION -> {
+				builder.addAction(buildNotificationAction(context, accountID, notification,  "Favourite", NotificationAction.FAVORITE));
+				builder.addAction(buildNotificationAction(context, accountID, notification,  "Bookmark", NotificationAction.BOOKMARK));
+//				builder.addAction(buildNotificationAction(context, accountID, notification,  "Reblog", NotificationAction.REBLOG));
+			}
+//			case FOLLOW -> builder.addAction(buildNotificationAction(context, accountID, notification, null, "Refollow", NotificationAction.FAVORITE));
+		}
+
 		nm.notify(accountID, GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++, builder.build());
+	}
+
+	private Notification.Action buildNotificationAction(Context context, String accountID, org.joinmastodon.android.model.Notification notification, String title, NotificationAction action){
+		Intent notificationIntent=new Intent(context, PushNotificationReceiver.class);
+		notificationIntent.putExtra("fromNotificationAction", true);
+		notificationIntent.putExtra("accountID", accountID);
+		notificationIntent.putExtra("notificationAction", action.ordinal());
+		if(notification!=null){
+			notificationIntent.putExtra("notification", Parcels.wrap(notification));
+		}
+		PendingIntent actionPendingIntent =
+				PendingIntent.getBroadcast(context, 1, notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+		return new Notification.Action.Builder(null, title, actionPendingIntent).build();
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -105,7 +105,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 
 			if ( notificationId >= 0) {
 				NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-				notificationManager.cancel(notificationId);
+				notificationManager.cancel(accountID, notificationId);
 			}
 
 			if(intent.hasExtra("notification")){

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -9,6 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.Icon;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -19,6 +20,7 @@ import org.joinmastodon.android.api.requests.notifications.GetNotificationByID;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.model.NotificationAction;
 import org.joinmastodon.android.model.PushNotification;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.parceler.Parcels;
@@ -99,6 +101,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		Account self=AccountSessionManager.getInstance().getAccount(accountID).self;
 		String accountName="@"+self.username+"@"+AccountSessionManager.getInstance().getAccount(accountID).domain;
 		Notification.Builder builder;
+		Notification.Builder summaryNotification;
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.O){
 			boolean hasGroup=false;
 			List<NotificationChannelGroup> channelGroups=nm.getNotificationChannelGroups();
@@ -121,8 +124,12 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 				nm.createNotificationChannels(channels);
 			}
 			builder=new Notification.Builder(context, accountID+"_"+pn.notificationType);
+//			summaryNotification=new Notification.Builder(context, accountID);
 		}else{
 			builder=new Notification.Builder(context)
+					.setPriority(Notification.PRIORITY_DEFAULT)
+					.setDefaults(Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE);
+			summaryNotification=new Notification.Builder(context)
 					.setPriority(Notification.PRIORITY_DEFAULT)
 					.setDefaults(Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE);
 		}
@@ -131,11 +138,14 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		contentIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 		contentIntent.putExtra("fromNotification", true);
 		contentIntent.putExtra("accountID", accountID);
+		contentIntent.putExtra("notificationID", notificationId);
 		if(notification!=null){
 			contentIntent.putExtra("notification", Parcels.wrap(notification));
 		}
+
 		builder.setContentTitle(pn.title)
 				.setContentText(pn.body)
+				.setContentTitle(pn.title)
 				.setStyle(new Notification.BigTextStyle().bigText(pn.body))
 				.setSmallIcon(R.drawable.ic_ntf_logo)
 				.setContentIntent(PendingIntent.getActivity(context, notificationId, contentIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT))
@@ -143,7 +153,8 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 				.setShowWhen(true)
 				.setCategory(Notification.CATEGORY_SOCIAL)
 				.setAutoCancel(true)
-				.setColor(context.getColor(R.color.shortcut_icon_background));
+				.setColor(context.getColor(R.color.shortcut_icon_background))
+				.setGroup(accountID);
 
 		if (!GlobalUserPreferences.uniformNotificationIcon) {
 			builder.setSmallIcon(switch (pn.notificationType) {
@@ -165,6 +176,35 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		if(AccountSessionManager.getInstance().getLoggedInAccounts().size()>1){
 			builder.setSubText(accountName);
 		}
-		nm.notify(accountID, GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++, builder.build());
+
+
+		Intent actionIntent = new Intent(context, MainActivity.class);
+		actionIntent.putExtra("fromNotification", true);
+		actionIntent.putExtra("accountID", accountID);
+		actionIntent.putExtra("notificationID", notificationId);
+		if(notification!=null){
+			actionIntent.putExtra("status", notification.status.id);
+//			actionIntent.putExtra("notification", Parcels.wrap(notification));
+		}
+		PendingIntent actionPendingIntent =
+				PendingIntent.getBroadcast(context, 0, actionIntent, 0);
+
+		switch (pn.notificationType) {
+			case FAVORITE -> builder.setSmallIcon(R.drawable.ic_fluent_star_24_filled);
+			case REBLOG -> builder.setSmallIcon(R.drawable.ic_fluent_arrow_repeat_all_24_filled);
+			case FOLLOW -> builder.setSmallIcon(R.drawable.ic_fluent_person_add_24_filled);
+			case MENTION -> builder.setSmallIcon(R.drawable.ic_fluent_mention_24_filled);
+			case POLL -> builder.setSmallIcon(R.drawable.ic_fluent_poll_24_filled);
+			default -> builder.setSmallIcon(R.drawable.ic_ntf_logo);
+		}
+
+		if (pn.notificationType == PushNotification.Type.MENTION) {
+			actionIntent.putExtra("notificationAction", NotificationAction.REBLOG.ordinal());
+			builder.addAction(new Notification.Action.Builder(null, "Favorite", actionPendingIntent).build());
+		}
+
+		notificationId++;
+		nm.notify(accountID, GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId, builder.build());
+
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -31,6 +31,7 @@ import org.parceler.Parcels;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.Callback;
@@ -228,7 +229,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		notificationIntent.putExtra("notificationAction", action.ordinal());
 		notificationIntent.putExtra("notification", Parcels.wrap(notification));
 		PendingIntent actionPendingIntent =
-				PendingIntent.getBroadcast(context, 1, notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+				PendingIntent.getBroadcast(context, new Random().nextInt(), notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_ONE_SHOT);
 
 		return new Notification.Action.Builder(null, title, actionPendingIntent).build();
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -199,14 +199,21 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		}
 
 
+		if (notification != null) {
 		switch (pn.notificationType) {
 			case MENTION -> {
-				builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
-				builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
-				if (notification != null && notification.status.visibility != StatusPrivacy.DIRECT)
-					builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.REBLOG));
+				if(!notification.status.favourited)
+					builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
+				if(!notification.status.bookmarked)
+					builder.addAction(buildNotificationAction(context, accountID, notification, context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
+				if(notification.status.visibility != StatusPrivacy.DIRECT)
+						builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.REBLOG));
 			}
-//			case FOLLOW -> builder.addAction(buildNotificationAction(context, accountID, notification, null, "Refollow", NotificationAction.FAVORITE));
+			case FOLLOW -> {
+//				if ( notification != null && notification.status.account.)
+				builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_follow), NotificationAction.FAVORITE));
+			}
+		}
 		}
 
 		nm.notify(accountID, GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++, builder.build());

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -24,8 +24,10 @@ import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.NotificationAction;
+import org.joinmastodon.android.model.Preferences;
 import org.joinmastodon.android.model.PushNotification;
 import org.joinmastodon.android.model.Status;
+import org.joinmastodon.android.model.StatusPrivacy;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.parceler.Parcels;
 
@@ -110,7 +112,11 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 					switch (NotificationAction.values()[intent.getIntExtra("notificationAction", 0)]) {
 						case FAVORITE -> new SetStatusFavorited(statusID, true).exec(accountID);
 						case BOOKMARK -> new SetStatusBookmarked(statusID, true).exec(accountID);
-//						case REBLOG -> new SetStatusReblogged(notification.status.id, true, GlobalUserPreferences.);
+						case REBLOG -> {
+							AccountSessionManager accountSessionManager = AccountSessionManager.getInstance();
+							Preferences preferences = accountSessionManager.getAccount(accountID).preferences;
+							new SetStatusReblogged(notification.status.id, true, preferences.postingDefaultVisibility).exec(accountID);
+						}
 						default -> Log.w(TAG, "onReceive: Failed to get NotificationAction");
 					}
 				}
@@ -197,7 +203,8 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 			case MENTION -> {
 				builder.addAction(buildNotificationAction(context, accountID, notification,  "Favourite", NotificationAction.FAVORITE));
 				builder.addAction(buildNotificationAction(context, accountID, notification,  "Bookmark", NotificationAction.BOOKMARK));
-//				builder.addAction(buildNotificationAction(context, accountID, notification,  "Reblog", NotificationAction.REBLOG));
+				if (notification != null && notification.status.visibility != StatusPrivacy.DIRECT)
+					builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.REBLOG));
 			}
 //			case FOLLOW -> builder.addAction(buildNotificationAction(context, accountID, notification, null, "Refollow", NotificationAction.FAVORITE));
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -100,6 +100,12 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		}
 		if(intent.getBooleanExtra("fromNotificationAction", false)) {
 			String accountID=intent.getStringExtra("accountID");
+			int notificationId=intent.getIntExtra("notificationId", -1);
+
+			if ( notificationId >= 0) {
+				NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+				notificationManager.cancel(notificationId);
+			}
 
 			if(intent.hasExtra("notification")){
 				org.joinmastodon.android.model.Notification notification=Parcels.unwrap(intent.getParcelableExtra("notification"));
@@ -194,35 +200,33 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 			builder.setSubText(accountName);
 		}
 
+		int id = GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++;
 
 		if (notification != null) {
 			switch (pn.notificationType) {
 				case MENTION, STATUS -> {
-					if(!notification.status.favourited)
-						builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
-					if(!notification.status.bookmarked)
-						builder.addAction(buildNotificationAction(context, accountID, notification, context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
+					builder.addAction(buildNotificationAction(context, id, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
+					builder.addAction(buildNotificationAction(context, id, accountID, notification, context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
 					if(notification.status.visibility != StatusPrivacy.DIRECT)
-							builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.BOOST));
+						builder.addAction(buildNotificationAction(context, id, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.BOOST));
 				}
 				case UPDATE -> {
 					if(notification.status.reblogged)
-						builder.addAction(buildNotificationAction(context, accountID, notification,  context.getString(R.string.sk_notification_action_unboost), NotificationAction.UNBOOST));
+						builder.addAction(buildNotificationAction(context, id, accountID, notification,  context.getString(R.string.sk_notification_action_unboost), NotificationAction.UNBOOST));
 				}
 			}
 		}
 
-		nm.notify(accountID, GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++, builder.build());
+		nm.notify(accountID, id, builder.build());
 	}
 
-	private Notification.Action buildNotificationAction(Context context, String accountID, org.joinmastodon.android.model.Notification notification, String title, NotificationAction action){
+	private Notification.Action buildNotificationAction(Context context, int notificationId, String accountID, org.joinmastodon.android.model.Notification notification, String title, NotificationAction action){
 		Intent notificationIntent=new Intent(context, PushNotificationReceiver.class);
+		notificationIntent.putExtra("notificationId", notificationId);
 		notificationIntent.putExtra("fromNotificationAction", true);
 		notificationIntent.putExtra("accountID", accountID);
 		notificationIntent.putExtra("notificationAction", action.ordinal());
-		if(notification!=null){
-			notificationIntent.putExtra("notification", Parcels.wrap(notification));
-		}
+		notificationIntent.putExtra("notification", Parcels.wrap(notification));
 		PendingIntent actionPendingIntent =
 				PendingIntent.getBroadcast(context, 1, notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
 

--- a/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
@@ -1,0 +1,6 @@
+package org.joinmastodon.android.model;
+
+public enum NotificationAction {
+    FAVORITE,
+    REBLOG
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
@@ -2,5 +2,6 @@ package org.joinmastodon.android.model;
 
 public enum NotificationAction {
     FAVORITE,
-    REBLOG
+    REBLOG,
+    BOOKMARK,
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
@@ -2,6 +2,8 @@ package org.joinmastodon.android.model;
 
 public enum NotificationAction {
     FAVORITE,
-    REBLOG,
+    BOOST,
+    UNBOOST,
     BOOKMARK,
+    REPLY,
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
@@ -5,5 +5,4 @@ public enum NotificationAction {
     BOOST,
     UNBOOST,
     BOOKMARK,
-    REPLY,
 }

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -265,4 +265,5 @@
     <string name="sk_notification_action_favorite">Favorite</string>
     <string name="sk_notification_action_bookmark">Bookmark</string>
     <string name="sk_notification_action_boost">Boost</string>
+    <string name="sk_notification_action_follow">Refollow</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -262,4 +262,5 @@
     <string name="sk_follow_as">Follow from other account</string>
     <string name="sk_followed_as">Followed from %s</string>
     <string name="sk_settings_hide_fab">Auto-hide Compose button</string>
+    <string name="sk_notification_action_boost">Boost</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -265,5 +265,6 @@
     <string name="sk_notification_action_favorite">Favorite</string>
     <string name="sk_notification_action_bookmark">Bookmark</string>
     <string name="sk_notification_action_boost">Boost</string>
+    <string name="sk_notification_action_unboost">Unboost</string>
     <string name="sk_notification_action_follow">Refollow</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -266,5 +266,4 @@
     <string name="sk_notification_action_bookmark">Bookmark</string>
     <string name="sk_notification_action_boost">Boost</string>
     <string name="sk_notification_action_unboost">Unboost</string>
-    <string name="sk_notification_action_follow">Refollow</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -262,5 +262,7 @@
     <string name="sk_follow_as">Follow from other account</string>
     <string name="sk_followed_as">Followed from %s</string>
     <string name="sk_settings_hide_fab">Auto-hide Compose button</string>
+    <string name="sk_notification_action_favorite">Favorite</string>
+    <string name="sk_notification_action_bookmark">Bookmark</string>
     <string name="sk_notification_action_boost">Boost</string>
 </resources>


### PR DESCRIPTION
Adds actions to some notifications. Current supported notifications are `UPDATE`, `MENTION` and  `STATUS`. For `MENTION` and  `STATUS` are actions to Favorite, Bookmark and Boost (only shown if the post can be boosted, uses the account's default visibility for boosting) shown.  Each action can only be clicked once, after which the notification disappears. 
![Mention Notification with actions](https://user-images.githubusercontent.com/63370021/221676510-3f1c3221-8ad0-451a-b409-26b773a2d955.png)

For `UPDATE` notifications, an action to unboost the post is added.

For the other notifications, `reblog`, `follow`, `favourite`, `poll` are items, which are not actionable (there is nothing the user can do about them, except see them, which should rather be to tap the notification), and I'm too inexperienced with the two admin related ones. From the app is the type for `follow_request` missing, which could have the actions `Accept` and `Decline`, but I'm not sure why it's missing.

