### PR TITLE
Feat(tabs): add unread badge to notification tab

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -47,7 +47,7 @@ public class GlobalUserPreferences{
 	public static boolean collapseLongPosts;
 	public static boolean spectatorMode;
 	public static boolean autoHideFab;
-	public static long lastNotificationOpenedTime;
+	public static boolean unreadNotifications;
 	public static String publishButtonText;
 	public static ThemePreference theme;
 	public static ColorPreference color;
@@ -102,7 +102,7 @@ public class GlobalUserPreferences{
 		collapseLongPosts=prefs.getBoolean("collapseLongPosts", true);
 		spectatorMode=prefs.getBoolean("spectatorMode", false);
 		autoHideFab=prefs.getBoolean("autoHideFab", true);
-		lastNotificationOpenedTime=prefs.getLong("lastNotificationOpenedTime", 0);
+		unreadNotifications=prefs.getBoolean("unreadNotifications", false);
 		publishButtonText=prefs.getString("publishButtonText", "");
 		theme=ThemePreference.values()[prefs.getInt("theme", 0)];
 		recentLanguages=fromJson(prefs.getString("recentLanguages", "{}"), recentLanguagesType, new HashMap<>());
@@ -152,7 +152,7 @@ public class GlobalUserPreferences{
 				.putBoolean("collapseLongPosts", collapseLongPosts)
 				.putBoolean("spectatorMode", spectatorMode)
 				.putBoolean("autoHideFab", autoHideFab)
-				.putLong("lastNotificationOpenedTime", lastNotificationOpenedTime)
+				.putBoolean("unreadNotifications", unreadNotifications)
 				.putString("publishButtonText", publishButtonText)
 				.putBoolean("bottomEncoding", bottomEncoding)
 				.putInt("theme", theme.ordinal())

--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -47,6 +47,7 @@ public class GlobalUserPreferences{
 	public static boolean collapseLongPosts;
 	public static boolean spectatorMode;
 	public static boolean autoHideFab;
+	public static long lastNotificationOpenedTime;
 	public static String publishButtonText;
 	public static ThemePreference theme;
 	public static ColorPreference color;
@@ -101,6 +102,7 @@ public class GlobalUserPreferences{
 		collapseLongPosts=prefs.getBoolean("collapseLongPosts", true);
 		spectatorMode=prefs.getBoolean("spectatorMode", false);
 		autoHideFab=prefs.getBoolean("autoHideFab", true);
+		lastNotificationOpenedTime=prefs.getLong("lastNotificationOpenedTime", 0);
 		publishButtonText=prefs.getString("publishButtonText", "");
 		theme=ThemePreference.values()[prefs.getInt("theme", 0)];
 		recentLanguages=fromJson(prefs.getString("recentLanguages", "{}"), recentLanguagesType, new HashMap<>());
@@ -150,6 +152,7 @@ public class GlobalUserPreferences{
 				.putBoolean("collapseLongPosts", collapseLongPosts)
 				.putBoolean("spectatorMode", spectatorMode)
 				.putBoolean("autoHideFab", autoHideFab)
+				.putLong("lastNotificationOpenedTime", lastNotificationOpenedTime)
 				.putString("publishButtonText", publishButtonText)
 				.putBoolean("bottomEncoding", bottomEncoding)
 				.putInt("theme", theme.ordinal())

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -76,6 +76,8 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 									@Override
 									public void onSuccess(org.joinmastodon.android.model.Notification result){
 										MastodonAPIController.runInBackground(()->PushNotificationReceiver.this.notify(context, pn, accountID, result));
+										GlobalUserPreferences.unreadNotifications = true;
+										GlobalUserPreferences.save();
 									}
 
 									@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -16,32 +16,23 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
+import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
+
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
-import org.joinmastodon.android.api.requests.markers.SaveMarkers;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.discover.DiscoverFragment;
 import org.joinmastodon.android.model.Account;
-import org.joinmastodon.android.model.Notification;
-import org.joinmastodon.android.model.PaginatedResponse;
 import org.joinmastodon.android.ui.AccountSwitcherSheet;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.ui.views.TabBar;
 import org.parceler.Parcels;
 
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import androidx.annotation.IdRes;
-import androidx.annotation.Nullable;
 import me.grishka.appkit.FragmentStackActivity;
-import me.grishka.appkit.api.Callback;
-import me.grishka.appkit.api.ErrorResponse;
-import me.grishka.appkit.api.SimpleCallback;
 import me.grishka.appkit.fragments.AppKitFragment;
 import me.grishka.appkit.fragments.LoaderFragment;
 import me.grishka.appkit.fragments.OnBackPressedListener;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -64,7 +64,6 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	private View tabBarWrap;
 	private ImageView tabBarAvatar;
 	private ImageView notificationTabIcon;
-	private boolean notificationBadged = false;
 	@IdRes
 	private int currentTab=R.id.tab_home;
 
@@ -131,21 +130,7 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		ViewImageLoader.load(tabBarAvatar, null, new UrlImageLoaderRequest(self.avatar, V.dp(28), V.dp(28)));
 
 		notificationTabIcon=content.findViewById(R.id.tab_notifications);
-
-		AccountSessionManager.getInstance()
-				.getAccount(accountID).getCacheController()
-				.getNotifications(null, 1, false, false, true, new Callback<>() {
-					@Override
-					public void onSuccess(PaginatedResponse<List<Notification>> result) {
-						notificationBadged = result.items.get(0).createdAt.isAfter(Instant.ofEpochMilli(GlobalUserPreferences.lastNotificationOpenedTime));
-						setNotificationBadge();
-					}
-
-					@Override
-					public void onError(ErrorResponse error) {
-						error.showToast(getContext());
-					}
-				});
+		setNotificationBadge();
 
 		if(savedInstanceState==null){
 			getChildFragmentManager().beginTransaction()
@@ -287,8 +272,7 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		}
 
 		if(tab == R.id.tab_notifications){
-			notificationBadged=false;
-			GlobalUserPreferences.lastNotificationOpenedTime = System.currentTimeMillis();
+			GlobalUserPreferences.unreadNotifications = false;
 			GlobalUserPreferences.save();
 			setNotificationBadge();
 		}
@@ -367,6 +351,6 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	}
 
 	private void setNotificationBadge() {
-			notificationTabIcon.setImageDrawable(getContext().getDrawable(notificationBadged ? R.drawable.ic_notifications_tab_badged : R.drawable.ic_fluent_alert_28_selector));
+			notificationTabIcon.setImageDrawable(getContext().getDrawable(GlobalUserPreferences.unreadNotifications ? R.drawable.ic_notifications_tab_badged : R.drawable.ic_fluent_alert_28_selector));
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -16,21 +16,32 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
+import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.api.requests.markers.SaveMarkers;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.discover.DiscoverFragment;
 import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.model.Notification;
+import org.joinmastodon.android.model.PaginatedResponse;
 import org.joinmastodon.android.ui.AccountSwitcherSheet;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.ui.views.TabBar;
 import org.parceler.Parcels;
 
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
 import me.grishka.appkit.FragmentStackActivity;
+import me.grishka.appkit.api.Callback;
+import me.grishka.appkit.api.ErrorResponse;
+import me.grishka.appkit.api.SimpleCallback;
 import me.grishka.appkit.fragments.AppKitFragment;
 import me.grishka.appkit.fragments.LoaderFragment;
 import me.grishka.appkit.fragments.OnBackPressedListener;
@@ -52,6 +63,8 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	private TabBar tabBar;
 	private View tabBarWrap;
 	private ImageView tabBarAvatar;
+	private ImageView notificationTabIcon;
+	private boolean notificationBadged = false;
 	@IdRes
 	private int currentTab=R.id.tab_home;
 
@@ -116,6 +129,23 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 		tabBarAvatar.setClipToOutline(true);
 		Account self=AccountSessionManager.getInstance().getAccount(accountID).self;
 		ViewImageLoader.load(tabBarAvatar, null, new UrlImageLoaderRequest(self.avatar, V.dp(28), V.dp(28)));
+
+		notificationTabIcon=content.findViewById(R.id.tab_notifications);
+
+		AccountSessionManager.getInstance()
+				.getAccount(accountID).getCacheController()
+				.getNotifications(null, 1, false, false, true, new Callback<>() {
+					@Override
+					public void onSuccess(PaginatedResponse<List<Notification>> result) {
+						notificationBadged = result.items.get(0).createdAt.isAfter(Instant.ofEpochMilli(GlobalUserPreferences.lastNotificationOpenedTime));
+						setNotificationBadge();
+					}
+
+					@Override
+					public void onError(ErrorResponse error) {
+						error.showToast(getContext());
+					}
+				});
 
 		if(savedInstanceState==null){
 			getChildFragmentManager().beginTransaction()
@@ -255,6 +285,14 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 				scrollable.scrollToTop();
 			return;
 		}
+
+		if(tab == R.id.tab_notifications){
+			notificationBadged=false;
+			GlobalUserPreferences.lastNotificationOpenedTime = System.currentTimeMillis();
+			GlobalUserPreferences.save();
+			setNotificationBadge();
+		}
+
 		getChildFragmentManager().beginTransaction().hide(fragmentForTab(currentTab)).show(newFragment).commit();
 		maybeTriggerLoading(newFragment);
 		currentTab=tab;
@@ -326,5 +364,9 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 //		getChildFragmentManager().putFragment(outState, "searchFragment", searchFragment);
 //		getChildFragmentManager().putFragment(outState, "notificationsFragment", notificationsFragment);
 //		getChildFragmentManager().putFragment(outState, "profileFragment", profileFragment);
+	}
+
+	private void setNotificationBadge() {
+			notificationTabIcon.setImageDrawable(getContext().getDrawable(notificationBadged ? R.drawable.ic_notifications_tab_badged : R.drawable.ic_fluent_alert_28_selector));
 	}
 }

--- a/mastodon/src/main/res/drawable/ic_notifications_tab_badged.xml
+++ b/mastodon/src/main/res/drawable/ic_notifications_tab_badged.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_fluent_alert_28_selector" android:left="2dp" android:right="2dp" android:top="2dp" android:bottom="2dp"/>
+    <item android:width="14dp" android:height="14dp" android:gravity="top|right">
+        <shape android:shape="oval">
+            <stroke android:color="?android:colorPrimary" android:width="2dp"/>
+            <solid android:color="?android:colorAccent"/>
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
Adds a badge to the notification tab icon, if the user has unread notifications. It disappears, when the notifications tab is opened. The badge will not get added, if the app is currently open and a new notification arrives, only if it's closed.

![Tabs with a badge on the notification icon](https://user-images.githubusercontent.com/63370021/222264278-28895f8b-fdaa-495f-a71a-b39f89324892.png)
