### PR TITLE
feat(notification): add reply action

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -12,11 +12,8 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
-import android.service.notification.StatusBarNotification;
 import android.text.TextUtils;
 import android.util.Log;
-
-import androidx.annotation.RequiresApi;
 
 import org.joinmastodon.android.api.MastodonAPIController;
 import org.joinmastodon.android.api.requests.notifications.GetNotificationByID;
@@ -283,7 +280,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 			req.spoilerText = "re: " + notification.status.spoilerText;
 		}
 
-//		new CreateStatus(req, UUID.randomUUID().toString()).exec(accountID);
+		new CreateStatus(req, UUID.randomUUID().toString()).exec(accountID);
 
 		NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		Notification.Builder builder = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O ?
@@ -295,8 +292,6 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		Notification repliedNotification = builder.setSmallIcon(R.drawable.ic_ntf_logo)
 				.setContentText(context.getString(R.string.sk_notification_action_replied, notification.status.account.getDisplayUsername()))
 				.build();
-//		notificationManager.cancel(accountID, notificationId);
-//		notificationManager.notify(notificationId, repliedNotification);
 		notificationManager.notify(accountID, notificationId, repliedNotification);
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -5,17 +5,22 @@ import android.app.NotificationChannel;
 import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.app.RemoteInput;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.service.notification.StatusBarNotification;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.RequiresApi;
+
 import org.joinmastodon.android.api.MastodonAPIController;
 import org.joinmastodon.android.api.requests.notifications.GetNotificationByID;
+import org.joinmastodon.android.api.requests.statuses.CreateStatus;
 import org.joinmastodon.android.api.requests.statuses.SetStatusBookmarked;
 import org.joinmastodon.android.api.requests.statuses.SetStatusFavorited;
 import org.joinmastodon.android.api.requests.statuses.SetStatusReblogged;
@@ -32,6 +37,7 @@ import org.parceler.Parcels;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.Callback;
@@ -44,6 +50,8 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 	private static final String TAG="PushNotificationReceive";
 
 	public static final int NOTIFICATION_ID=178;
+	private static final String ACTION_KEY_TEXT_REPLY = "ACTION_KEY_TEXT_REPLY";
+
 	private static final int SUMMARY_ID = 791;
 	private static int notificationId = 0;
 
@@ -122,6 +130,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 						case BOOKMARK -> new SetStatusBookmarked(statusID, true).exec(accountID);
 						case BOOST -> new SetStatusReblogged(notification.status.id, true, preferences.postingDefaultVisibility).exec(accountID);
 						case UNBOOST -> new SetStatusReblogged(notification.status.id, false, preferences.postingDefaultVisibility).exec(accountID);
+						case REPLY -> handleReplyAction(context, accountID, intent, notification, notificationId, preferences);
 						default -> Log.w(TAG, "onReceive: Failed to get NotificationAction");
 					}
 				}
@@ -208,10 +217,14 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		if (notification != null){
 			switch (pn.notificationType){
 				case MENTION, STATUS -> {
+					if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N){
+						builder.addAction(buildReplyAction(context, id, accountID, notification));
+					}
 					builder.addAction(buildNotificationAction(context, id, accountID, notification,  context.getString(R.string.sk_notification_action_favorite), NotificationAction.FAVORITE));
 					builder.addAction(buildNotificationAction(context, id, accountID, notification, context.getString(R.string.sk_notification_action_bookmark), NotificationAction.BOOKMARK));
-					if(notification.status.visibility != StatusPrivacy.DIRECT)
+					if(notification.status.visibility != StatusPrivacy.DIRECT) {
 						builder.addAction(buildNotificationAction(context, id, accountID, notification,  context.getString(R.string.sk_notification_action_boost), NotificationAction.BOOST));
+					}
 				}
 				case UPDATE -> {
 					if(notification.status.reblogged)
@@ -233,5 +246,57 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		PendingIntent actionPendingIntent = PendingIntent.getBroadcast(context, new Random().nextInt(), notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_ONE_SHOT);
 
 		return new Notification.Action.Builder(null, title, actionPendingIntent).build();
+	}
+
+	private Notification.Action buildReplyAction(Context context, int notificationId, String accountID, org.joinmastodon.android.model.Notification notification){
+		String replyLabel = context.getResources().getString(R.string.sk_notification_action_reply);
+		RemoteInput remoteInput = new RemoteInput.Builder(ACTION_KEY_TEXT_REPLY)
+				.setLabel(replyLabel)
+				.build();
+
+		Intent notificationIntent=new Intent(context, PushNotificationReceiver.class);
+		notificationIntent.putExtra("notificationId", notificationId);
+		notificationIntent.putExtra("fromNotificationAction", true);
+		notificationIntent.putExtra("accountID", accountID);
+		notificationIntent.putExtra("notificationAction", NotificationAction.REPLY.ordinal());
+		notificationIntent.putExtra("notification", Parcels.wrap(notification));
+
+		int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT : PendingIntent.FLAG_UPDATE_CURRENT;
+		PendingIntent replyPendingIntent = PendingIntent.getBroadcast(context, new Random().nextInt(), notificationIntent,flags);
+		return new Notification.Action.Builder(null, replyLabel, replyPendingIntent).addRemoteInput(remoteInput).build();
+	}
+
+	private void handleReplyAction(Context context, String accountID, Intent intent, org.joinmastodon.android.model.Notification notification, int notificationId, Preferences preferences) {
+		Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);
+		if (remoteInput == null) {
+			Log.e(TAG, "handleReplyAction: Could not get reply input");
+			return;
+		}
+		CharSequence input = remoteInput.getCharSequence(ACTION_KEY_TEXT_REPLY);
+
+		CreateStatus.Request req=new CreateStatus.Request();
+		req.status = input.toString();
+		req.language = preferences.postingDefaultLanguage;
+		req.visibility = preferences.postingDefaultVisibility;
+		req.inReplyToId = notification.status.id;
+		if(!notification.status.spoilerText.isEmpty() && GlobalUserPreferences.prefixRepliesWithRe && !notification.status.spoilerText.startsWith("re: ")){
+			req.spoilerText = "re: " + notification.status.spoilerText;
+		}
+
+//		new CreateStatus(req, UUID.randomUUID().toString()).exec(accountID);
+
+		NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		Notification.Builder builder = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O ?
+				new Notification.Builder(context, accountID+"_"+notification.type) :
+				new Notification.Builder(context)
+					.setPriority(Notification.PRIORITY_DEFAULT)
+					.setDefaults(Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE);
+
+		Notification repliedNotification = builder.setSmallIcon(R.drawable.ic_ntf_logo)
+				.setContentText(context.getString(R.string.sk_notification_action_replied, notification.status.account.getDisplayUsername()))
+				.build();
+//		notificationManager.cancel(accountID, notificationId);
+//		notificationManager.notify(notificationId, repliedNotification);
+		notificationManager.notify(accountID, notificationId, repliedNotification);
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
@@ -5,4 +5,5 @@ public enum NotificationAction {
     BOOST,
     UNBOOST,
     BOOKMARK,
+    REPLY,
 }

--- a/mastodon/src/main/res/values/strings_sk.xml
+++ b/mastodon/src/main/res/values/strings_sk.xml
@@ -266,4 +266,6 @@
     <string name="sk_notification_action_bookmark">Bookmark</string>
     <string name="sk_notification_action_boost">Boost</string>
     <string name="sk_notification_action_unboost">Unboost</string>
+    <string name="sk_notification_action_reply">Reply</string>
+    <string name="sk_notification_action_replied">Successfully replied to the post by %s</string>
 </resources>


### PR DESCRIPTION
Adds a reply action to the `status` and `mention` notifications.
![Notification with reply action](https://user-images.githubusercontent.com/63370021/222900238-c260a557-d588-4c88-aa79-2b0001843148.png)

The user then has the option to directly reply, the reply will use the user's default posting language and status visibility, if the status had a spoiler warning, the reply will have the same spoiler text prepended with `re:`, similar to how it works in the compose screen.

After replying, the notification will get replaced by a new one, stating `Successfully replied to the post by [account name]`, although it didn't work for me reliably.
