### PR TITLE
feat: add mute timer

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
@@ -4,8 +4,15 @@ import org.joinmastodon.android.api.MastodonAPIRequest;
 import org.joinmastodon.android.model.Relationship;
 
 public class SetAccountMuted extends MastodonAPIRequest<Relationship>{
-	public SetAccountMuted(String id, boolean muted){
+	public SetAccountMuted(String id, boolean muted, long duration){
 		super(HttpMethod.POST, "/accounts/"+id+"/"+(muted ? "mute" : "unmute"), Relationship.class);
-		setRequestBody(new Object());
+		setRequestBody(new Request(duration));
+	}
+
+	private static class Request{
+		public long duration;
+		public Request(long duration){
+			this.duration=duration;
+		}
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
@@ -6,7 +6,7 @@ import org.joinmastodon.android.model.Relationship;
 public class SetAccountMuted extends MastodonAPIRequest<Relationship>{
 	public SetAccountMuted(String id, boolean muted, long duration){
 		super(HttpMethod.POST, "/accounts/"+id+"/"+(muted ? "mute" : "unmute"), Relationship.class);
-		setRequestBody(new Request(duration));
+		setRequestBody(muted ? new Request(duration): new Object());
 	}
 
 	private static class Request{

--- a/mastodon/src/main/res/layout/item_mute_duration.xml
+++ b/mastodon/src/main/res/layout/item_mute_duration.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:gravity="center"
+    android:paddingVertical="12dp">
+
+    <TextView
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:textColor="?android:textColorPrimary"
+        android:text="@string/mo_mute_label"
+        android:textSize="16sp"/>
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_weight="0"
+        android:layout_marginEnd="16dp"
+        android:maxWidth="140dp"
+        android:background="@drawable/bg_inline_button"
+        android:elevation="0dp"
+        android:ellipsize="middle"
+        android:fontFamily="sans-serif-medium"
+        android:singleLine="true"
+        android:stateListAnimator="@null"
+        android:textColor="?android:textColorPrimary"
+        android:textSize="16sp"
+        android:text="Duration" />
+</LinearLayout>

--- a/mastodon/src/main/res/menu/mute_duration.xml
+++ b/mastodon/src/main/res/menu/mute_duration.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/duration_indefinite" android:title="@string/mo_duration_indefinite" />
+    <item android:id="@+id/duration_minutes_5" android:title="@string/mo_duration_minutes_5"/>
+    <item android:id="@+id/duration_minutes_30" android:title="@string/mo_duration_minutes_30"/>
+    <item android:id="@+id/duration_hours_1" android:title="@string/mo_duration_hours_1"/>
+    <item android:id="@+id/duration_hours_6" android:title="@string/mo_duration_hours_6"/>
+    <item android:id="@+id/duration_days_1" android:title="@string/mo_duration_days_1"/>
+    <item android:id="@+id/duration_days_3" android:title="@string/mo_duration_days_3"/>
+    <item android:id="@+id/duration_days_7" android:title="@string/mo_duration_days_7"/>
+</menu>

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -34,4 +34,16 @@
     <string name="mo_fab_compose">Compose</string>
     <string name="mo_sending_error">Error publishing</string>
 
+    <!--    duration labels-->
+    <string name="mo_mute_label">Duration:</string>
+    <string name="mo_duration_indefinite">Indefinite</string>
+    <string name="mo_duration_minutes_5">5 minutes</string>
+    <string name="mo_duration_minutes_30">30 minutes</string>
+    <string name="mo_duration_hours_1">1 hour</string>
+    <string name="mo_duration_hours_6">6 hours</string>
+    <string name="mo_duration_days_1">1 day</string>
+    <string name="mo_duration_days_3">3 days</string>
+    <string name="mo_duration_days_7">7 day</string>
+
+
 </resources>


### PR DESCRIPTION
Adds a user selectable mute timer to the mute confirmation dialog. The options are the same as on the web UI.
![Unmute dialog](https://user-images.githubusercontent.com/63370021/223228757-48465d72-73ce-4fe3-bb25-12360994606a.png)
![Unmute dialog with expanded options](https://user-images.githubusercontent.com/63370021/223228751-2f271507-d854-4829-962b-3bf9f1c1393d.png)

The dialog will not show the duration picker when unmuting someone.

I'm aware, that the current design is not optimal, however, so is my ability to improve it, so I will just leave it like it is for now.