### PR TITLE
fix(translation/de): replace indefinite

### DIFF
--- a/mastodon/src/main/res/values-de-rDE/strings_mo.xml
+++ b/mastodon/src/main/res/values-de-rDE/strings_mo.xml
@@ -33,7 +33,7 @@
     <string name="mo_duration_days_1">1 Tag</string>
     <string name="mo_duration_days_3">3 Tage</string>
     <string name="mo_mute_label">Dauer:</string>
-    <string name="mo_duration_indefinite">Unbestimmt</string>
+    <string name="mo_duration_indefinite">Unbegrenzt</string>
     <string name="mo_duration_minutes_5">5 Minuten</string>
     <string name="mo_duration_minutes_30">30 Minuten</string>
     <string name="mo_change_default_reply_visibility_to_unlisted">Standard Antwortsichtbarkeit auf nicht aufgelistet ändern</string>


### PR DESCRIPTION
Changes the translation of `Indefinite` from `Unbestimmt` (meaning more in the direction of unknown), to `Unbegrenzt` (meaning limitless), as the time is actually known and has no time limit.

cc @dontobi, including you as a reviewer here.