### PR TITLE
fix: apply URI InputType correctly

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -151,7 +151,7 @@ public class EditTimelinesFragment extends BaseRecyclerFragment<TimelineDefiniti
         FrameLayout inputWrap = new FrameLayout(getContext());
         EditText input = new EditText(getContext());
         input.setHint(R.string.sk_example_domain);
-        input.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
+        input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         params.setMargins(V.dp(16), V.dp(4), V.dp(16), V.dp(16));
         input.setLayoutParams(params);

--- a/mastodon/src/main/res/layout/header_welcome_custom.xml
+++ b/mastodon/src/main/res/layout/header_welcome_custom.xml
@@ -36,7 +36,7 @@
 		android:layout_marginTop="16dp"
 		android:layout_marginBottom="8dp"
 		android:layout_marginHorizontal="16dp"
-		android:inputType="textFilter|textNoSuggestions|textUri"
+		android:inputType="textUri|textNoSuggestions"
 		android:singleLine="true"
 		android:imeOptions="actionGo"
 		android:drawableStart="@drawable/ic_fluent_globe_20_regular"


### PR DESCRIPTION
Fixes an issue with the implementation from #96 and #100, both were not correctly applied on all phones, and would still show the wrong input type.