### PR TITLE
fix(custom-timelines): lookup profile by url

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
@@ -47,6 +47,7 @@ public class CustomLocalTimelineFragment extends StatusListFragment {
                         result=result.stream().filter(new StatusFilterPredicate(accountID, Filter.FilterContext.PUBLIC)).collect(Collectors.toList());
                         result.stream().forEach(status -> {
                             status.account.acct += "@"+domain;
+                            status.mentions.forEach(mention -> mention.id = null);
                             status.reloadWhenClicked = true;
                         });
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -100,7 +100,7 @@ public class HtmlParser{
 			}
 		}
 
-		Map<String, String> idsByUrl=mentions.stream().collect(Collectors.toMap(m->m.url, m->m.id));
+		Map<String, String> idsByUrl=mentions.stream().filter(mention -> mention.id != null).collect(Collectors.toMap(m->m.url, m->m.id));
 		// Hashtags in remote posts have remote URLs, these have local URLs so they don't match.
 //		Map<String, String> tagsByUrl=tags.stream().collect(Collectors.toMap(t->t.url, t->t.name));
 


### PR DESCRIPTION
Closes #107. Instead of using the (wrong) profileID on CustomTimelines, use the URL, which will be correctly resolved.

https://user-images.githubusercontent.com/63370021/225416672-d3b50d9e-9a9a-422b-8db1-d33c6e9fafdc.mp4

