### PR TITLE
Feat:  Add recents URL sharing (Pixel exclusive)

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/DomainManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/DomainManager.java
@@ -1,0 +1,84 @@
+package org.joinmastodon.android;
+
+import android.app.Activity;
+import android.app.NotificationManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
+import android.graphics.drawable.Icon;
+import android.net.Uri;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.browser.customtabs.CustomTabsIntent;
+
+import org.joinmastodon.android.api.MastodonAPIController;
+import org.joinmastodon.android.api.PushSubscriptionManager;
+import org.joinmastodon.android.api.requests.accounts.GetOwnAccount;
+import org.joinmastodon.android.api.requests.accounts.GetPreferences;
+import org.joinmastodon.android.api.requests.accounts.GetWordFilters;
+import org.joinmastodon.android.api.requests.instance.GetCustomEmojis;
+import org.joinmastodon.android.api.requests.instance.GetInstance;
+import org.joinmastodon.android.api.requests.oauth.CreateOAuthApp;
+import org.joinmastodon.android.api.session.AccountActivationInfo;
+import org.joinmastodon.android.api.session.AccountSession;
+import org.joinmastodon.android.api.session.AccountSessionManager;
+import org.joinmastodon.android.events.EmojiUpdatedEvent;
+import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.model.Application;
+import org.joinmastodon.android.model.Emoji;
+import org.joinmastodon.android.model.EmojiCategory;
+import org.joinmastodon.android.model.Filter;
+import org.joinmastodon.android.model.Instance;
+import org.joinmastodon.android.model.Preferences;
+import org.joinmastodon.android.model.Token;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import me.grishka.appkit.api.Callback;
+import me.grishka.appkit.api.ErrorResponse;
+
+public class DomainManager {
+	private static final String TAG="DomainManager";
+
+	private static final DomainManager instance=new DomainManager();
+
+	private String currentDomain = "";
+
+
+	public static DomainManager getInstance(){
+		return instance;
+	}
+
+	private DomainManager(){
+
+	}
+
+	public String getCurrentDomain() {
+		return currentDomain;
+	}
+
+	public void setCurrentDomain(String domain) {
+		Log.e(TAG, "setCurrentDomain: " + domain );
+		this.currentDomain = domain;
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/DomainManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/DomainManager.java
@@ -78,7 +78,6 @@ public class DomainManager {
 	}
 
 	public void setCurrentDomain(String domain) {
-		Log.e(TAG, "setCurrentDomain: " + domain );
 		this.currentDomain = domain;
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/MainActivity.java
@@ -2,8 +2,10 @@ package org.joinmastodon.android;
 
 import android.Manifest;
 import android.app.Fragment;
+import android.app.assist.AssistContent;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -36,6 +38,7 @@ import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
 
 public class MainActivity extends FragmentStackActivity{
+
 	@Override
 	protected void onCreate(@Nullable Bundle savedInstanceState){
 		UiUtils.setUserPreferredTheme(this);
@@ -90,6 +93,7 @@ public class MainActivity extends FragmentStackActivity{
 			AccountSession accountSession;
 			try{
 				accountSession=AccountSessionManager.getInstance().getAccount(accountID);
+				DomainManager.getInstance().setCurrentDomain(accountSession.domain);
 			}catch(IllegalStateException x){
 				return;
 			}
@@ -177,4 +181,11 @@ public class MainActivity extends FragmentStackActivity{
 			super.onBackPressed();
 		}
 	}
+	@Override
+	public void onProvideAssistContent(AssistContent outContent) {
+		super.onProvideAssistContent(outContent);
+
+		outContent.setWebUri(Uri.parse(DomainManager.getInstance().getCurrentDomain()));
+	}
+
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -13,6 +13,7 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -20,11 +21,14 @@ import android.view.animation.TranslateAnimation;
 import android.widget.ImageButton;
 import android.widget.Toolbar;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.GlobalUserPreferences;
+import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.accounts.GetAccountRelationships;
 import org.joinmastodon.android.api.requests.polls.SubmitPollVote;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.events.PollUpdatedEvent;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.DisplayItemsParent;
@@ -102,6 +106,10 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		}
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N)
 			setRetainInstance(true);
+	}
+
+	public void setAssistContentUri() {
+		DomainManager.getInstance().setCurrentDomain(AccountSessionManager.getInstance().getAccount(accountID).domain);
 	}
 
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -74,7 +74,7 @@ import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public abstract class BaseStatusListFragment<T extends DisplayItemsParent> extends BaseRecyclerFragment<T> implements PhotoViewerHost, ScrollableToTop{
+public abstract class BaseStatusListFragment<T extends DisplayItemsParent> extends BaseRecyclerFragment<T> implements PhotoViewerHost, ScrollableToTop, DomainDisplay{
 	protected ArrayList<StatusDisplayItem> displayItems=new ArrayList<>();
 	protected DisplayItemsAdapter adapter;
 	protected String accountID;
@@ -106,10 +106,6 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		}
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N)
 			setRetainInstance(true);
-	}
-
-	public void setAssistContentUri() {
-		DomainManager.getInstance().setCurrentDomain(AccountSessionManager.getInstance().getAccount(accountID).domain);
 	}
 
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
@@ -39,8 +39,8 @@ public class CustomLocalTimelineFragment extends StatusListFragment {
     }
 
     @Override
-    public void setAssistContentUri() {
-        DomainManager.getInstance().setCurrentDomain(domain);
+    public String getDomain() {
+        return domain;
     }
 
     @Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
@@ -1,6 +1,9 @@
 package org.joinmastodon.android.fragments;
 
 import android.app.Activity;
+
+import org.joinmastodon.android.DomainManager;
+import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.api.requests.timelines.GetPublicTimeline;
 import org.joinmastodon.android.model.Filter;
 import org.joinmastodon.android.model.Status;
@@ -33,6 +36,11 @@ public class CustomLocalTimelineFragment extends StatusListFragment {
     private void updateTitle(String domain) {
         this.domain = domain;
         setTitle(this.domain);
+    }
+
+    @Override
+    public void setAssistContentUri() {
+        DomainManager.getInstance().setCurrentDomain(domain);
     }
 
     @Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/DomainDisplay.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/DomainDisplay.java
@@ -1,0 +1,16 @@
+package org.joinmastodon.android.fragments;
+
+import org.joinmastodon.android.api.session.AccountSession;
+import org.joinmastodon.android.api.session.AccountSessionManager;
+
+public interface DomainDisplay {
+	void scrollToTop();
+
+	default String getDomain(){
+		AccountSession session = AccountSessionManager.getInstance().getLastActiveAccount();
+		if (session != null)
+			return session.domain;
+		else
+			return "";
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/DomainDisplay.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/DomainDisplay.java
@@ -4,7 +4,6 @@ import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 
 public interface DomainDisplay {
-	void scrollToTop();
 
 	default String getDomain(){
 		AccountSession session = AccountSessionManager.getInstance().getLastActiveAccount();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.Toast;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.tags.GetHashtag;
@@ -44,11 +45,18 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment {
 	}
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/tags/" + hashtag;
+	}
+
+
+	@Override
 	public void onAttach(Activity activity){
 		super.onAttach(activity);
 		updateTitle(getArguments().getString("hashtag"));
 		following=getArguments().getBoolean("following", false);
 		setHasOptionsMenu(true);
+		DomainManager.getInstance().setCurrentDomain(getDomain());
 	}
 
 	private void updateTitle(String hashtagName) {

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -19,6 +19,7 @@ import android.widget.LinearLayout;
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.session.AccountSession;
@@ -194,6 +195,8 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	@Override
 	public void onHiddenChanged(boolean hidden){
 		super.onHiddenChanged(hidden);
+		if (!hidden && fragmentForTab(currentTab) instanceof  DomainDisplay display)
+			DomainManager.getInstance().setCurrentDomain(display.getDomain());
 		fragmentForTab(currentTab).onHiddenChanged(hidden);
 	}
 
@@ -266,6 +269,10 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			GlobalUserPreferences.unreadNotifications = false;
 			GlobalUserPreferences.save();
 			setNotificationBadge();
+		}
+
+		if (newFragment instanceof DomainDisplay display) {
+			DomainManager.getInstance().setCurrentDomain(display.getDomain());
 		}
 
 		getChildFragmentManager().beginTransaction().hide(fragmentForTab(currentTab)).show(newFragment).commit();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -35,6 +35,7 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.squareup.otto.Subscribe;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
@@ -70,7 +71,7 @@ import me.grishka.appkit.fragments.OnBackPressedListener;
 import me.grishka.appkit.utils.CubicBezierInterpolator;
 import me.grishka.appkit.utils.V;
 
-public class HomeTabFragment extends MastodonToolbarFragment implements ScrollableToTop, OnBackPressedListener {
+public class HomeTabFragment extends MastodonToolbarFragment implements ScrollableToTop, OnBackPressedListener, DomainDisplay {
 	private static final int ANNOUNCEMENTS_RESULT = 654;
 
 	private String accountID;
@@ -196,6 +197,10 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 				if (fragments[position] instanceof BaseRecyclerFragment<?> page){
 					if(!page.loaded && !page.isDataLoading()) page.loadData();
 				}
+
+				//update recent app list url
+				if (fragments[position] instanceof DomainDisplay page)
+					DomainManager.getInstance().setCurrentDomain(page.getDomain());
 			}
 		});
 
@@ -278,6 +283,14 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 				error.showToast(getActivity());
 			}
 		}).exec(accountID);
+	}
+
+	@Override
+	public String getDomain() {
+		if (fragments[pager.getCurrentItem()] instanceof DomainDisplay page) {
+			return page.getDomain();
+		}
+		return DomainDisplay.super.getDomain();
 	}
 
 	private void addListsToOverflowMenu() {

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTimelineFragment.java
@@ -43,6 +43,11 @@ public class HomeTimelineFragment extends StatusListFragment {
 	}
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/home";
+	}
+
+	@Override
 	public void onAttach(Activity activity){
 		super.onAttach(activity);
 		if (getParentFragment() instanceof HomeTabFragment home) parent = home;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
@@ -37,7 +37,7 @@ import me.grishka.appkit.api.ErrorResponse;
 import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.utils.V;
 
-public class NotificationsFragment extends MastodonToolbarFragment implements ScrollableToTop{
+public class NotificationsFragment extends MastodonToolbarFragment implements ScrollableToTop, DomainDisplay{
 
 	private TabLayout tabLayout;
 	private ViewPager2 pager;
@@ -47,6 +47,11 @@ public class NotificationsFragment extends MastodonToolbarFragment implements Sc
 	private NotificationsListFragment allNotificationsFragment, mentionsFragment, postsFragment;
 
 	private String accountID;
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/notifications";
+	}
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
@@ -53,6 +53,11 @@ public class NotificationsListFragment extends BaseStatusListFragment<Notificati
 	}
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/notifications";
+	}
+
+	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
 		E.register(this);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/PinnableStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/PinnableStatusListFragment.java
@@ -14,7 +14,7 @@ import org.joinmastodon.android.model.TimelineDefinition;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class PinnableStatusListFragment extends StatusListFragment {
+public abstract class PinnableStatusListFragment extends StatusListFragment implements DomainDisplay {
     protected boolean pinnedUpdated;
     protected List<TimelineDefinition> pinnedTimelines;
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -50,7 +50,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.viewpager2.widget.ViewPager2;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.GlobalUserPreferences;
+import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.accounts.GetAccountByID;
 import org.joinmastodon.android.api.requests.accounts.GetAccountRelationships;
@@ -189,6 +191,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			profileAccountID=account.id;
 			isOwnProfile=AccountSessionManager.getInstance().isSelf(accountID, account);
 			loaded=true;
+			DomainManager.getInstance().setCurrentDomain(account.url);
 			if(!isOwnProfile)
 				loadRelationship();
 		}else{
@@ -857,6 +860,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 //			aboutFragment.setNote(relationship.note, accountID, profileAccountID);
 		}
 		notifyButton.setContentDescription(getString(relationship.notifying ? R.string.sk_user_post_notifications_on : R.string.sk_user_post_notifications_off, '@'+account.username));
+		DomainManager.getInstance().setCurrentDomain(account.url);
 	}
 
 	public ImageButton getFab() {

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -191,7 +191,6 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			profileAccountID=account.id;
 			isOwnProfile=AccountSessionManager.getInstance().isSelf(accountID, account);
 			loaded=true;
-			DomainManager.getInstance().setCurrentDomain(account.url);
 			if(!isOwnProfile)
 				loadRelationship();
 		}else{
@@ -210,6 +209,14 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 	public void onAttach(Activity activity){
 		super.onAttach(activity);
 		setHasOptionsMenu(true);
+	}
+
+	@Override
+	public void onHiddenChanged(boolean hidden) {
+		super.onHiddenChanged(hidden);
+		if (!hidden) {
+			DomainManager.getInstance().setCurrentDomain(account.url);
+		}
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import androidx.recyclerview.widget.RecyclerView;
 import me.grishka.appkit.Nav;
 
-public abstract class StatusListFragment extends BaseStatusListFragment<Status>{
+public abstract class StatusListFragment extends BaseStatusListFragment<Status> implements DomainDisplay{
 	protected EventListener eventListener=new EventListener();
 
 	protected List<StatusDisplayItem> buildDisplayItems(Status s){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/StatusListFragment.java
@@ -7,6 +7,7 @@ import com.squareup.otto.Subscribe;
 
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.GlobalUserPreferences;
+import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.events.PollUpdatedEvent;
 import org.joinmastodon.android.events.RemoveAccountPostsEvent;
 import org.joinmastodon.android.events.StatusCountersUpdatedEvent;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
@@ -3,6 +3,7 @@ package org.joinmastodon.android.fragments;
 import android.os.Bundle;
 import android.view.View;
 
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.statuses.GetStatusContext;
 import org.joinmastodon.android.events.StatusCreatedEvent;
@@ -25,8 +26,13 @@ import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.SimpleCallback;
 
-public class ThreadFragment extends StatusListFragment{
+public class ThreadFragment extends StatusListFragment implements DomainDisplay{
 	protected Status mainStatus;
+
+	@Override
+	public String getDomain() {
+		return mainStatus.url;
+	}
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -38,6 +44,8 @@ public class ThreadFragment extends StatusListFragment{
 		data.add(mainStatus);
 		onAppendItems(Collections.singletonList(mainStatus));
 		setTitle(HtmlParser.parseCustomEmoji(getString(R.string.post_from_user, mainStatus.account.displayName), mainStatus.account.emojis));
+
+		DomainManager.getInstance().setCurrentDomain(getDomain());
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverAccountsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverAccountsFragment.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.accounts.GetAccountRelationships;
 import org.joinmastodon.android.api.requests.accounts.GetFollowSuggestions;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ProfileFragment;
 import org.joinmastodon.android.fragments.ScrollableToTop;
@@ -49,13 +50,18 @@ import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class DiscoverAccountsFragment extends BaseRecyclerFragment<DiscoverAccountsFragment.AccountWrapper> implements ScrollableToTop, IsOnTop {
+public class DiscoverAccountsFragment extends BaseRecyclerFragment<DiscoverAccountsFragment.AccountWrapper> implements ScrollableToTop, IsOnTop, DomainDisplay {
 	private String accountID;
 	private Map<String, Relationship> relationships=Collections.emptyMap();
 	private GetAccountRelationships relationshipsRequest;
 
 	public DiscoverAccountsFragment(){
 		super(20);
+	}
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/explore/suggestions";
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -19,8 +19,10 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.joinmastodon.android.BuildConfig;
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.ScrollableToTop;
 import org.joinmastodon.android.fragments.ListTimelinesFragment;
 import org.joinmastodon.android.ui.SimpleViewHolder;
@@ -38,7 +40,7 @@ import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.fragments.OnBackPressedListener;
 import me.grishka.appkit.utils.V;
 
-public class DiscoverFragment extends AppKitFragment implements ScrollableToTop, OnBackPressedListener{
+public class DiscoverFragment extends AppKitFragment implements ScrollableToTop, OnBackPressedListener, DomainDisplay {
 
 	private TabLayout tabLayout;
 	private ViewPager2 pager;
@@ -63,6 +65,17 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 	private Runnable searchDebouncer=this::onSearchChangedDebounced;
 
 //	private final boolean noFederated = !GlobalUserPreferences.showFederatedTimeline;
+
+	@Override
+	public String getDomain() {
+		if (searchActive) {
+			return searchFragment.getDomain();
+		}
+		if (tabViews[tabLayout.getSelectedTabPosition()] instanceof DomainDisplay page) {
+			return page.getDomain();
+		}
+		return DomainDisplay.super.getDomain() + "/explore";
+	}
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -127,6 +140,9 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 					if(!page.loaded && !page.isDataLoading())
 						page.loadData();
 				}
+
+				if (_page instanceof DomainDisplay display)
+					DomainManager.getInstance().setCurrentDomain(display.getDomain());
 			}
 		});
 
@@ -208,7 +224,9 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 		tabLayoutMediator.attach();
 		tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener(){
 			@Override
-			public void onTabSelected(TabLayout.Tab tab){}
+			public void onTabSelected(TabLayout.Tab tab){
+				DomainManager.getInstance().setCurrentDomain(getDomain());
+			}
 
 			@Override
 			public void onTabUnselected(TabLayout.Tab tab){}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.trends.GetTrendingLinks;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
 import org.joinmastodon.android.model.Card;
@@ -35,13 +36,18 @@ import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class DiscoverNewsFragment extends BaseRecyclerFragment<Card> implements ScrollableToTop, IsOnTop {
+public class DiscoverNewsFragment extends BaseRecyclerFragment<Card> implements ScrollableToTop, IsOnTop, DomainDisplay {
 	private String accountID;
 	private List<ImageLoaderRequest> imageRequests=Collections.emptyList();
 	private DiscoverInfoBannerHelper bannerHelper=new DiscoverInfoBannerHelper(DiscoverInfoBannerHelper.BannerType.TRENDING_LINKS);
 
 	public DiscoverNewsFragment(){
 		super(10);
+	}
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/explore/links";
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverPostsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverPostsFragment.java
@@ -20,6 +20,11 @@ public class DiscoverPostsFragment extends StatusListFragment implements IsOnTop
 	private DiscoverInfoBannerHelper bannerHelper=new DiscoverInfoBannerHelper(DiscoverInfoBannerHelper.BannerType.TRENDING_POSTS);
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/explore/posts";
+	}
+
+	@Override
 	protected void doLoadData(int offset, int count){
 		currentRequest=new GetTrendingStatuses(offset, count)
 				.setCallback(new SimpleCallback<>(this){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/FederatedTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/FederatedTimelineFragment.java
@@ -25,6 +25,11 @@ public class FederatedTimelineFragment extends StatusListFragment {
 		return true;
 	}
 
+	@Override
+	public String getDomain() {
+		return super.getDomain() + "/public";
+	}
+
 
 	@Override
 	protected void doLoadData(int offset, int count){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/LocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/LocalTimelineFragment.java
@@ -24,6 +24,10 @@ public class LocalTimelineFragment extends StatusListFragment {
 		return true;
 	}
 
+	@Override
+	public String getDomain() {
+		return super.getDomain() + "/public/local";
+	}
 
 	@Override
 	protected void doLoadData(int offset, int count){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
@@ -253,7 +253,7 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult>{
 	}
 
 	public void setQuery(String q){
-		if(Objects.equals(q, currentQuery))
+		if(Objects.equals(q, currentQuery) || q.isBlank())
 			return;
 		if(currentRequest!=null){
 			currentRequest.cancel();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/SearchFragment.java
@@ -58,6 +58,11 @@ public class SearchFragment extends BaseStatusListFragment<SearchResult>{
 	}
 
 	@Override
+	public String getDomain() {
+		return super.getDomain() + "/search";
+	}
+
+	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
 		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.N)

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.trends.GetTrendingHashtags;
+import org.joinmastodon.android.fragments.DomainDisplay;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
 import org.joinmastodon.android.model.Hashtag;
@@ -24,12 +25,17 @@ import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop {
+public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop, DomainDisplay {
 	private String accountID;
 	private DiscoverInfoBannerHelper bannerHelper=new DiscoverInfoBannerHelper(DiscoverInfoBannerHelper.BannerType.TRENDING_HASHTAGS);
 
 	public TrendingHashtagsFragment(){
 		super(10);
+	}
+
+	@Override
+	public String getDomain() {
+		return DomainDisplay.super.getDomain() + "/explore/tags";
 	}
 
 	@Override


### PR DESCRIPTION
Closes #119 by using the Pixel exclusive URL feature in the recent screen. It shows the web domain of the content that is displayed, for example, in the profile view the URL of the profile is shown, in a timeline, the timeline URL, etc…. Custom timelines will only show the default URL, without the added path for the local timeline.

This is a bit of a hacky solution, as the app only has one actual activity, but many different fragments with different URLs.

![Local Timeline](https://user-images.githubusercontent.com/63370021/225946204-20584d76-3058-4b73-af04-1c447093a46e.png)
![Custom Timeline](https://user-images.githubusercontent.com/63370021/225946216-e712841c-fdeb-459e-9ae1-80ab0654ef37.png)
![Post](https://user-images.githubusercontent.com/63370021/225946236-bbe79fa4-eead-4b4b-b3ad-4cb1f0044f8b.png)
