### PR TITLE
Feat: redesign external share sheet

### DIFF
--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@
 				<data android:scheme="moshidon-android-auth" android:host="callback"/>
 			</intent-filter>
 		</activity>
-		<activity android:name=".ExternalShareActivity" android:exported="true" android:configChanges="orientation|screenSize" android:windowSoftInputMode="adjustResize">
+		<activity android:name=".ExternalShareActivity" android:exported="true" android:configChanges="orientation|screenSize" android:windowSoftInputMode="adjustResize"
+			android:theme="@style/TransparentDialog">
 			<intent-filter>
 				<action android:name="android.intent.action.SEND"/>
 				<category android:name="android.intent.category.DEFAULT"/>

--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -3,7 +3,6 @@ package org.joinmastodon.android;
 import android.app.Fragment;
 import android.content.ClipData;
 import android.content.Intent;
-import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -34,7 +33,6 @@ public class ExternalShareActivity extends FragmentStackActivity{
 			}else if(sessions.size()==1){
 				openComposeFragment(sessions.get(0).getID());
 			}else{
-				getWindow().setBackgroundDrawable(new ColorDrawable(0xff000000));
 				UiUtils.pickAccount(this, null, R.string.choose_account, 0,
 						session -> openComposeFragment(session.getID()),
 						b -> b.setOnCancelListener(d -> finish())

--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -11,6 +11,7 @@ import android.widget.Toast;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.ComposeFragment;
+import org.joinmastodon.android.ui.AccountSwitcherSheet;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
 import java.util.ArrayList;
@@ -33,10 +34,7 @@ public class ExternalShareActivity extends FragmentStackActivity{
 			}else if(sessions.size()==1){
 				openComposeFragment(sessions.get(0).getID());
 			}else{
-				UiUtils.pickAccount(this, null, R.string.choose_account, 0,
-						session -> openComposeFragment(session.getID()),
-						b -> b.setOnCancelListener(d -> finish())
-				);
+				new AccountSwitcherSheet(this, false, false, accountSession -> openComposeFragment(accountSession.getID())).show();
 			}
 		}
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -2,6 +2,7 @@ package org.joinmastodon.android.fragments;
 
 import android.app.Fragment;
 import android.app.NotificationManager;
+import android.content.Intent;
 import android.graphics.Outline;
 import android.os.Build;
 import android.os.Bundle;
@@ -21,6 +22,7 @@ import androidx.annotation.Nullable;
 
 import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.GlobalUserPreferences;
+import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
@@ -305,7 +307,10 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			for(AccountSession session:AccountSessionManager.getInstance().getLoggedInAccounts()){
 				options.add(session.self.displayName+"\n("+session.self.username+"@"+session.domain+")");
 			}
-			new AccountSwitcherSheet(getActivity()).show();
+			new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+				getActivity().finish();
+				getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
+			}).show();
 			return true;
 		}
 		if(tab==R.id.tab_search){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -19,13 +19,11 @@ import android.os.Bundle;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ImageSpan;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.SubMenu;
 import android.view.View;
 import android.view.ViewGroup;
@@ -94,13 +92,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
-import androidx.viewpager2.widget.ViewPager2;
+
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
@@ -110,7 +110,10 @@ public class AccountActivationFragment extends ToolbarFragment{
 
 	@Override
 	public void onToolbarNavigationClick(){
-		new AccountSwitcherSheet(getActivity()).show();
+		new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+			getActivity().finish();
+			getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
+		}).show();
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
@@ -28,6 +28,7 @@ import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import androidx.annotation.NonNull;
@@ -53,10 +54,14 @@ public class AccountSwitcherSheet extends BottomSheet{
 	private UsableRecyclerView list;
 	private List<WrappedAccount> accounts;
 	private ListImageLoaderWrapper imgLoader;
+	private final boolean logOutEnabled;
+	private final Consumer<AccountSession> onClick;
 
-	public AccountSwitcherSheet(@NonNull Activity activity){
+	public AccountSwitcherSheet(@NonNull Activity activity, boolean logOutEnabled, boolean addAccountEnabled, Consumer<AccountSession> onClick){
 		super(activity);
 		this.activity=activity;
+		this.logOutEnabled=logOutEnabled;
+		this.onClick=onClick;
 
 		accounts=AccountSessionManager.getInstance().getLoggedInAccounts().stream().map(WrappedAccount::new).collect(Collectors.toList());
 
@@ -70,17 +75,20 @@ public class AccountSwitcherSheet extends BottomSheet{
 		handle.setBackgroundResource(R.drawable.bg_bottom_sheet_handle);
 		adapter.addAdapter(new SingleViewRecyclerAdapter(handle));
 		adapter.addAdapter(new AccountsAdapter());
-		AccountViewHolder holder=new AccountViewHolder();
-		holder.more.setVisibility(View.GONE);
-		holder.currentIcon.setVisibility(View.GONE);
-		holder.name.setText(R.string.add_account);
-		holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
-		holder.avatar.setImageResource(R.drawable.ic_fluent_add_circle_24_filled);
-		holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
-		adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, ()->{
-			Nav.go(activity, CustomWelcomeFragment.class, null);
-			dismiss();
-		}));
+
+		if(addAccountEnabled){
+			AccountViewHolder holder = new AccountViewHolder();
+			holder.more.setVisibility(View.GONE);
+			holder.currentIcon.setVisibility(View.GONE);
+			holder.name.setText(R.string.add_account);
+			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
+			holder.avatar.setImageResource(R.drawable.ic_fluent_add_circle_24_filled);
+			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
+			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {
+				Nav.go(activity, CustomWelcomeFragment.class, null);
+				dismiss();
+			}));
+		}
 
 		list.setAdapter(adapter);
 		DividerItemDecoration divider=new DividerItemDecoration(activity, R.attr.colorPollVoted, .5f, 72, 16, DividerItemDecoration.NOT_FIRST);
@@ -211,6 +219,11 @@ public class AccountSwitcherSheet extends BottomSheet{
 				more.setVisibility(View.VISIBLE);
 				currentIcon.setVisibility(View.GONE);
 			}
+
+			if(!logOutEnabled){
+				more.setVisibility(View.GONE);
+				currentIcon.setVisibility(View.GONE);
+			}
 			menu.getMenu().findItem(R.id.log_out).setTitle(activity.getString(R.string.log_out_account, "@"+item.self.username));
 			UiUtils.enablePopupMenuIcons(activity, menu);
 		}
@@ -230,8 +243,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 		@Override
 		public void onClick(){
 			AccountSessionManager.getInstance().setLastActiveAccountID(item.getID());
-			activity.finish();
-			activity.startActivity(new Intent(activity, MainActivity.class));
+			dismiss();
+			onClick.accept(AccountSessionManager.getInstance().getAccount(item.getID()));
 		}
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Animatable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -80,7 +81,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 			AccountViewHolder holder = new AccountViewHolder();
 			holder.more.setVisibility(View.GONE);
 			holder.currentIcon.setVisibility(View.GONE);
-			holder.name.setText(R.string.add_account);
+			holder.display_name.setText(R.string.add_account);
 			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
 			holder.avatar.setImageResource(R.drawable.ic_fluent_add_circle_24_filled);
 			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
@@ -184,6 +185,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 
 	private class AccountViewHolder extends BindableViewHolder<AccountSession> implements ImageLoaderViewHolder, UsableRecyclerView.Clickable{
 		private final TextView name;
+		private final TextView display_name;
 		private final ImageView avatar;
 		private final ImageButton more;
 		private final View currentIcon;
@@ -192,6 +194,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 		public AccountViewHolder(){
 			super(activity, R.layout.item_account_switcher, list);
 			name=findViewById(R.id.name);
+			display_name=findViewById(R.id.display_name);
 			avatar=findViewById(R.id.avatar);
 			more=findViewById(R.id.more);
 			currentIcon=findViewById(R.id.current);
@@ -211,6 +214,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 		@SuppressLint("SetTextI18n")
 		@Override
 		public void onBind(AccountSession item){
+			display_name.setText(item.self.displayName);
 			name.setText("@"+item.self.username+"@"+item.domain);
 			if(AccountSessionManager.getInstance().getLastActiveAccountID().equals(item.getID())){
 				more.setVisibility(View.GONE);

--- a/mastodon/src/main/res/layout/item_account_switcher.xml
+++ b/mastodon/src/main/res/layout/item_account_switcher.xml
@@ -2,30 +2,53 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:orientation="horizontal"
 	android:layout_width="match_parent"
-	android:layout_height="48dp"
+	android:layout_height="wrap_content"
 	android:paddingLeft="20dp"
 	android:paddingRight="20dp"
+	android:paddingBottom="12dp"
 	android:gravity="center_vertical">
 	
 	<ImageView
 		android:id="@+id/avatar"
-		android:layout_width="32dp"
-		android:layout_height="32dp"
+		android:layout_width="48dp"
+		android:layout_height="48dp"
+		android:padding="2dp"
+		android:layout_gravity="center"
 		android:importantForAccessibility="no"/>
 
-	<TextView
-		android:id="@+id/name"
-		android:layout_width="0dp"
-		android:layout_height="wrap_content"
-		android:layout_weight="1"
-		android:layout_marginStart="24dp"
-		android:textSize="16sp"
-		android:textColor="?android:textColorPrimary"
-		android:singleLine="true"
-		android:ellipsize="end"/>
+	<LinearLayout
+		android:orientation="vertical"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content">
+
+		<TextView
+			android:id="@+id/display_name"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:layout_marginStart="24dp"
+			android:textSize="16sp"
+			android:textColor="?android:textColorPrimary"
+			android:singleLine="true"
+			android:ellipsize="end"/>
+
+		<TextView
+			android:id="@+id/name"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:layout_marginStart="24dp"
+			android:textSize="14sp"
+			android:textColor="?android:textColorSecondary"
+			android:singleLine="true"
+			android:ellipsize="end"/>
+
+	</LinearLayout>
+
 
 	<View
 		android:id="@+id/current"
+		android:layout_gravity="end|center"
 		android:layout_width="24dp"
 		android:layout_height="24dp"
 		android:background="@drawable/ic_fluent_checkmark_24_filled"

--- a/mastodon/src/main/res/values/styles.xml
+++ b/mastodon/src/main/res/values/styles.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+
+	<style name="TransparentDialog" parent="android:Theme.Dialog">
+	<item name="android:windowIsTranslucent">true</item>
+	<item name="android:windowBackground">@android:color/transparent</item>
+	<item name="android:windowContentOverlay">@null</item>
+	<item name="android:windowNoTitle">true</item>
+	<item name="android:windowIsFloating">true</item>
+	<item name="android:backgroundDimEnabled">false</item>
+	</style>
+
 	<style name="Theme.Mastodon.Light" parent="Theme.AppKit.Light">
 		<!-- needed to disable scrim on API 29+ -->
 		<item name="android:enforceNavigationBarContrast" tools:ignore="NewApi">false</item>


### PR DESCRIPTION
Closes #67. Removes the old share dialog and replaces it with a new transparent AccountSwitcherSheet. The AccountSwitcherSheet is refactored to be able to be used both for choosing and switching accounts.

Please note, that this UI design is not final has and has to still be polished before the next release.