### PR TITLE
fix(custom-timelines/polls): look up correct poll id

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
@@ -1,17 +1,21 @@
 package org.joinmastodon.android.fragments;
 
 import android.app.Activity;
+import android.os.Bundle;
 
 import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.api.requests.timelines.GetPublicTimeline;
 import org.joinmastodon.android.model.Filter;
 import org.joinmastodon.android.model.Status;
+import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.utils.StatusFilterPredicate;
+import org.parceler.Parcels;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.SimpleCallback;
 
 public class CustomLocalTimelineFragment extends StatusListFragment {
@@ -53,10 +57,17 @@ public class CustomLocalTimelineFragment extends StatusListFragment {
                             maxID=result.get(result.size()-1).id;
                         if (getActivity() == null) return;
                         result=result.stream().filter(new StatusFilterPredicate(accountID, Filter.FilterContext.PUBLIC)).collect(Collectors.toList());
-                        result.stream().forEach(status -> {
+                        result.forEach(status -> {
                             status.account.acct += "@"+domain;
                             status.mentions.forEach(mention -> mention.id = null);
+                            if (status.poll != null) {
+                                UiUtils.lookupStatus(getContext(),
+                                        status, accountID, null,
+                                        lookUpStatus -> status.poll.id = lookUpStatus.poll.id
+                                );
+                            }
                             status.reloadWhenClicked = true;
+
                         });
 
                         onDataLoaded(result, !result.isEmpty());


### PR DESCRIPTION
Closes #122. Polls did not work correctly in custom timelines, as the poll IDs are local to the user's server and would reference the wrong poll when loaded from a different server local timeline.

This can be solved by looking up the correct poll ID when loading a status with a poll in a custom timeline. It's not an ideal solution, as many unnecessary look-ups are done, in case the user never votes on them. Another solution would be to check when voting for the correct ID.