### PR TITLE
Feat: Add tab triple click action

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -631,6 +631,11 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		smoothScrollRecyclerViewToTop(list);
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
 	protected int getListWidthForMediaLayout(){
 		return list.getWidth();
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -238,6 +238,11 @@ public class EditTimelinesFragment extends BaseRecyclerFragment<TimelineDefiniti
     }
 
     @Override
+    public boolean isScrolledToTop() {
+        return list.getChildAt(0).getTop() == 0;
+    }
+
+    @Override
     public void onDestroy() {
         super.onDestroy();
         if (updated) UiUtils.restartApp();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/FollowRequestsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/FollowRequestsListFragment.java
@@ -149,6 +149,11 @@ public class FollowRequestsListFragment extends BaseRecyclerFragment<FollowReque
 		smoothScrollRecyclerViewToTop(list);
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
 	private class AccountsAdapter extends UsableRecyclerView.Adapter<AccountViewHolder> implements ImageLoaderRecyclerAdapter{
 
 		public AccountsAdapter(){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/FollowedHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/FollowedHashtagsFragment.java
@@ -76,6 +76,11 @@ public class FollowedHashtagsFragment extends BaseRecyclerFragment<Hashtag> impl
         smoothScrollRecyclerViewToTop(list);
     }
 
+    @Override
+    public boolean isScrolledToTop() {
+        return list.getChildAt(0).getTop() == 0;
+    }
+
     private class HashtagsAdapter extends RecyclerView.Adapter<HashtagViewHolder>{
         @NonNull
         @Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -480,6 +480,11 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 		((ScrollableToTop) fragments[pager.getCurrentItem()]).scrollToTop();
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		return ((ScrollableToTop) fragments[pager.getCurrentItem()]).isScrolledToTop();
+	}
+
 	public void hideNewPostsButton(){
 		if(!newPostsBtnShown)
 			return;

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -477,6 +477,11 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 
 	@Override
 	public void scrollToTop(){
+		if (((ScrollableToTop) fragments[pager.getCurrentItem()]).isScrolledToTop()) {
+			int nextPage = (pager.getCurrentItem() + 1) % count;
+			navigateTo(nextPage);
+			return;
+		}
 		((ScrollableToTop) fragments[pager.getCurrentItem()]).scrollToTop();
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ListTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ListTimelinesFragment.java
@@ -200,6 +200,11 @@ public class ListTimelinesFragment extends BaseRecyclerFragment<ListTimeline> im
 		 smoothScrollRecyclerViewToTop(list);
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
 	private class ListsAdapter extends RecyclerView.Adapter<ListViewHolder>{
 		 @NonNull
 		 @Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
@@ -202,6 +202,11 @@ public class NotificationsFragment extends MastodonToolbarFragment implements Sc
 
 	@Override
 	public void scrollToTop(){
+		if (getFragmentForPage(pager.getCurrentItem()).isScrolledToTop()) {
+			int nextPage = (pager.getCurrentItem() + 1) % tabViews.length;
+			pager.setCurrentItem(nextPage, true);
+			return;
+		}
 		getFragmentForPage(pager.getCurrentItem()).scrollToTop();
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsFragment.java
@@ -205,6 +205,11 @@ public class NotificationsFragment extends MastodonToolbarFragment implements Sc
 		getFragmentForPage(pager.getCurrentItem()).scrollToTop();
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		return getFragmentForPage(pager.getCurrentItem()).isScrolledToTop();
+	}
+
 	public void loadData(){
 		refreshFollowRequestsBadge();
 		if(allNotificationsFragment!=null && !allNotificationsFragment.loaded && !allNotificationsFragment.dataLoading)

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -1229,6 +1229,11 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		scrollView.smoothScrollTo(0, 0);
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
 	private void onFollowersOrFollowingClick(View v){
 		Bundle args=new Bundle();
 		args.putString("account", accountID);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ScrollableToTop.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ScrollableToTop.java
@@ -6,6 +6,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import me.grishka.appkit.utils.V;
 
 public interface ScrollableToTop{
+	boolean isScrolledToTop();
+
 	void scrollToTop();
 
 	/**

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverAccountsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverAccountsFragment.java
@@ -147,6 +147,11 @@ public class DiscoverAccountsFragment extends BaseRecyclerFragment<DiscoverAccou
 	}
 
 	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
+	@Override
 	public boolean isOnTop() {
 		return isRecyclerViewOnTop(list);
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -302,6 +302,15 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 		}
 	}
 
+	@Override
+	public boolean isScrolledToTop() {
+		if(!searchActive){
+			return ((ScrollableToTop)getFragmentForPage(pager.getCurrentItem())).isScrolledToTop();
+		}else{
+			return searchFragment.isScrolledToTop();
+		}
+	}
+
 	public void loadData(){
 		if(hashtagsFragment!=null && !hashtagsFragment.loaded && !hashtagsFragment.dataLoading)
 			hashtagsFragment.loadData();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
@@ -90,6 +90,11 @@ public class DiscoverNewsFragment extends BaseRecyclerFragment<Card> implements 
 	}
 
 	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
+	@Override
 	public boolean isOnTop() {
 		return isRecyclerViewOnTop(list);
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
@@ -75,6 +75,11 @@ public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> impl
 	}
 
 	@Override
+	public boolean isScrolledToTop() {
+		return list.getChildAt(0).getTop() == 0;
+	}
+
+	@Override
 	public boolean isOnTop() {
 		return isRecyclerViewOnTop(list);
 	}


### PR DESCRIPTION
Adds a double/triple click action to the tabs. When clicking the HomeTab a second time, and it's already scrolled to the top, it will cycle through the available timelines. The same feature is available on the notification tab.

https://user-images.githubusercontent.com/63370021/226114677-d15b5d61-4d02-4cba-be4d-b85c114bbf5f.mp4

