### PR TITLE
Feat: share URL to open

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -27,14 +27,23 @@ public class ExternalShareActivity extends FragmentStackActivity{
 		UiUtils.setUserPreferredTheme(this);
 		super.onCreate(savedInstanceState);
 		if(savedInstanceState==null){
+
+			String text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+			boolean isMastodonURL = UiUtils.looksLikeMastodonUrl(text);
+
 			List<AccountSession> sessions=AccountSessionManager.getInstance().getLoggedInAccounts();
 			if(sessions.isEmpty()){
 				Toast.makeText(this, R.string.err_not_logged_in, Toast.LENGTH_SHORT).show();
 				finish();
-			}else if(sessions.size()==1){
+			}else if(sessions.size()==1 && !isMastodonURL){
 				openComposeFragment(sessions.get(0).getID());
 			}else{
-				new AccountSwitcherSheet(this, false, false, accountSession -> openComposeFragment(accountSession.getID())).show();
+				new AccountSwitcherSheet(this, false, false, isMastodonURL, accountSession -> {
+					if(accountSession!=null)
+						openComposeFragment(accountSession.getID());
+					else
+						UiUtils.openURL(this, AccountSessionManager.getInstance().getLastActiveAccountID(), text);
+				}).show();
 			}
 		}
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -307,7 +307,7 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			for(AccountSession session:AccountSessionManager.getInstance().getLoggedInAccounts()){
 				options.add(session.self.displayName+"\n("+session.self.username+"@"+session.domain+")");
 			}
-			new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+			new AccountSwitcherSheet(getActivity(), true, true, false, accountSession -> {
 				getActivity().finish();
 				getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
 			}).show();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/AccountActivationFragment.java
@@ -110,7 +110,7 @@ public class AccountActivationFragment extends ToolbarFragment{
 
 	@Override
 	public void onToolbarNavigationClick(){
-		new AccountSwitcherSheet(getActivity(), true, true, accountSession -> {
+		new AccountSwitcherSheet(getActivity(), true, true, false, accountSession -> {
 			getActivity().finish();
 			getActivity().startActivity(new Intent(getActivity(), MainActivity.class));
 		}).show();

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
@@ -2,13 +2,11 @@ package org.joinmastodon.android.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -18,23 +16,21 @@ import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
 import org.joinmastodon.android.GlobalUserPreferences;
-import org.joinmastodon.android.MainActivity;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.oauth.RevokeOauthToken;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
-import org.joinmastodon.android.fragments.onboarding.CustomWelcomeFragment;
 import org.joinmastodon.android.ui.utils.UiUtils;
-import org.w3c.dom.Text;
 
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.LinearLayoutManager;
 import me.grishka.appkit.Nav;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
@@ -59,7 +55,7 @@ public class AccountSwitcherSheet extends BottomSheet{
 	private final boolean logOutEnabled;
 	private final Consumer<AccountSession> onClick;
 
-	public AccountSwitcherSheet(@NonNull Activity activity, boolean logOutEnabled, boolean addAccountEnabled, Consumer<AccountSession> onClick){
+	public AccountSwitcherSheet(@NonNull Activity activity, boolean logOutEnabled, boolean addAccountEnabled, boolean showOpenURL, Consumer<AccountSession> onClick){
 		super(activity);
 		this.activity=activity;
 		this.logOutEnabled=logOutEnabled;
@@ -89,6 +85,22 @@ public class AccountSwitcherSheet extends BottomSheet{
 			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
 			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {
 				Nav.go(activity, CustomWelcomeFragment.class, null);
+				dismiss();
+			}));
+		}
+
+		if(showOpenURL) {
+			AccountViewHolder holder = new AccountViewHolder();
+			holder.more.setVisibility(View.GONE);
+			holder.currentIcon.setVisibility(View.GONE);
+			holder.display_name.setVisibility(View.VISIBLE);
+			holder.display_add_account.setVisibility(View.VISIBLE);
+			holder.display_add_account.setText(R.string.mo_share_open_url);
+			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
+			holder.avatar.setImageResource(R.drawable.ic_fluent_open_24_regular);
+			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
+			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {
+				onClick.accept(null);
 				dismiss();
 			}));
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/AccountSwitcherSheet.java
@@ -49,9 +49,9 @@ import me.grishka.appkit.views.UsableRecyclerView;
 
 public class AccountSwitcherSheet extends BottomSheet{
 	private final Activity activity;
-	private UsableRecyclerView list;
-	private List<WrappedAccount> accounts;
-	private ListImageLoaderWrapper imgLoader;
+	private final UsableRecyclerView list;
+	private final List<WrappedAccount> accounts;
+	private final ListImageLoaderWrapper imgLoader;
 	private final boolean logOutEnabled;
 	private final Consumer<AccountSession> onClick;
 
@@ -76,11 +76,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 
 		if(addAccountEnabled){
 			AccountViewHolder holder = new AccountViewHolder();
-			holder.more.setVisibility(View.GONE);
-			holder.currentIcon.setVisibility(View.GONE);
 			holder.display_name.setVisibility(View.GONE);
 			holder.display_add_account.setVisibility(View.VISIBLE);
-			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
 			holder.avatar.setImageResource(R.drawable.ic_fluent_add_circle_24_filled);
 			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
 			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {
@@ -91,12 +88,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 
 		if(showOpenURL) {
 			AccountViewHolder holder = new AccountViewHolder();
-			holder.more.setVisibility(View.GONE);
-			holder.currentIcon.setVisibility(View.GONE);
-			holder.display_name.setVisibility(View.VISIBLE);
 			holder.display_add_account.setVisibility(View.VISIBLE);
 			holder.display_add_account.setText(R.string.mo_share_open_url);
-			holder.avatar.setScaleType(ImageView.ScaleType.CENTER);
 			holder.avatar.setImageResource(R.drawable.ic_fluent_open_24_regular);
 			holder.avatar.setImageTintList(ColorStateList.valueOf(UiUtils.getThemeColor(activity, android.R.attr.textColorPrimary)));
 			adapter.addAdapter(new ClickableSingleViewRecyclerAdapter(holder.itemView, () -> {

--- a/mastodon/src/main/res/layout/item_account_switcher.xml
+++ b/mastodon/src/main/res/layout/item_account_switcher.xml
@@ -9,6 +9,7 @@
 	
 	<ImageView
 		android:id="@+id/avatar"
+		android:scaleType="center"
 		android:layout_width="36dp"
 		android:layout_height="36dp"
 		android:importantForAccessibility="no"/>
@@ -63,6 +64,7 @@
 		android:id="@+id/current"
 		android:layout_width="24dp"
 		android:layout_height="24dp"
+		android:visibility="gone"
 		android:background="@drawable/ic_fluent_checkmark_24_filled"
 		android:backgroundTint="?android:textColorSecondary"
 		android:contentDescription="@string/current_account"/>
@@ -71,6 +73,7 @@
 		android:id="@+id/more"
 		android:layout_width="24dp"
 		android:layout_height="24dp"
+		android:visibility="gone"
 		android:src="@drawable/ic_fluent_more_vertical_24_regular"
 		android:tint="?android:textColorSecondary"
 		android:contentDescription="@string/more_options"

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -48,5 +48,7 @@
     <string name="mo_duration_days_3">3 days</string>
     <string name="mo_duration_days_7">7 days</string>
 
+    <string name="mo_share_open_url">Open in App</string>
+
 
 </resources>


### PR DESCRIPTION
Adds the options to the share menu to open a mastodon URL inside the app, instead of sharing it. This is a band-aid fix to https://github.com/sk22/megalodon/issues/450, as it does not actually solve the issue, just merely providing a work-around.

The option to open the URL will only be shown, if the shared text could be a mastodon link, otherwise the previous only the normal share sheet is shown. 

![Example of sharing a post link](https://user-images.githubusercontent.com/63370021/226131397-09ccc3ae-1833-4b72-a215-87f1718146c6.png)
