### PR TITLE
fix(home-double-tab): scroll up for new posts

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -1,6 +1,7 @@
 package org.joinmastodon.android.fragments;
 
 import static org.joinmastodon.android.GlobalUserPreferences.reduceMotion;
+import static org.joinmastodon.android.GlobalUserPreferences.showNewPostsButton;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
@@ -477,7 +478,8 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 
 	@Override
 	public void scrollToTop(){
-		if (((ScrollableToTop) fragments[pager.getCurrentItem()]).isScrolledToTop() && !GlobalUserPreferences.disableDoubleTapToSwipe) {
+		if (((ScrollableToTop) fragments[pager.getCurrentItem()]).isScrolledToTop() &&
+				!GlobalUserPreferences.disableDoubleTapToSwipe && !newPostsBtnShown) {
 			int nextPage = (pager.getCurrentItem() + 1) % count;
 			navigateTo(nextPage);
 			return;


### PR DESCRIPTION
Fixes an issue, where tapping the home tab would cycle instead of showing new posts.