### PR TITLE
fix(hometimeline): scroll up on tapping new post button

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -562,8 +562,8 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 
 	private void onNewPostsBtnClick(View view) {
 		if(newPostsBtnShown){
-			hideNewPostsButton();
 			scrollToTop();
+			hideNewPostsButton();
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue, where clicking on the show new posts button would switch timelines instead of scrolling up.