### PR TITLE
fix(recent-url): show settings URL

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -36,6 +36,7 @@ import android.widget.Toast;
 import com.squareup.otto.Subscribe;
 
 import org.joinmastodon.android.BuildConfig;
+import org.joinmastodon.android.DomainManager;
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.GlobalUserPreferences.ColorPreference;
@@ -102,6 +103,8 @@ public class SettingsFragment extends MastodonToolbarFragment{
 		AccountSession session=AccountSessionManager.getInstance().getAccount(accountID);
 		Instance instance = AccountSessionManager.getInstance().getInstanceInfo(session.domain);
 		String instanceName = UiUtils.getInstanceName(accountID);
+
+		DomainManager.getInstance().setCurrentDomain(session.domain + "/settings");
 
 		if(GithubSelfUpdater.needSelfUpdating()){
 			GithubSelfUpdater updater=GithubSelfUpdater.getInstance();


### PR DESCRIPTION
Shows the instance settings URL in the settings page.

![Instance URL on the settings page](https://user-images.githubusercontent.com/63370021/227731097-cdc3eff8-4221-47a7-893a-aa5eb012d729.png)
