### PR TITLE
fix(notification): overwriting IDs

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -52,6 +52,7 @@ public class GlobalUserPreferences{
 	public static boolean compactReblogReplyLine;
 	public static boolean replyLineAboveHeader;
 	public static boolean swapBookmarkWithBoostAction;
+	public static int latestNotificationId = 0;
 	public static String publishButtonText;
 	public static ThemePreference theme;
 	public static ColorPreference color;
@@ -126,6 +127,7 @@ public class GlobalUserPreferences{
 		accountsWithLocalOnlySupport=prefs.getStringSet("accountsWithLocalOnlySupport", new HashSet<>());
 		accountsInGlitchMode=prefs.getStringSet("accountsInGlitchMode", new HashSet<>());
 		replyVisibility=prefs.getString("replyVisibility", null);
+		latestNotificationId=prefs.getInt("latestNotificationId", 0);
 
 		try {
 			if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
@@ -182,6 +184,7 @@ public class GlobalUserPreferences{
 				.putStringSet("accountsWithLocalOnlySupport", accountsWithLocalOnlySupport)
 				.putStringSet("accountsInGlitchMode", accountsInGlitchMode)
 				.putString("replyVisibility", replyVisibility)
+				.putInt("latestNotificationId", latestNotificationId)
 				.apply();
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -54,7 +54,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 	private static final String ACTION_KEY_TEXT_REPLY = "ACTION_KEY_TEXT_REPLY";
 
 	private static final int SUMMARY_ID = 791;
-	private static int notificationId = 0;
+	private static int notificationId = GlobalUserPreferences.latestNotificationId;
 
 	@Override
 	public void onReceive(Context context, Intent intent){
@@ -214,6 +214,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		}
 
 		int id = GlobalUserPreferences.keepOnlyLatestNotification ? NOTIFICATION_ID : notificationId++;
+		GlobalUserPreferences.save();
 
 		if (notification != null){
 			switch (pn.notificationType){


### PR DESCRIPTION
Closes #129, by saving the last notification ID, as discussed in the issue. Even tough, only $2^{31}-1$ can potentially now be received before the counter would roll over, I don't consider this probable. If a user achieves it, prompting them to clear the data/reinstall the app is a viable solution.

Please note, that this code was not verified to actually fix the issue, as it's incredibly hard to reproduce, but it should likely fix it.