### PR TITLE
fix: use BuilType defined REDIRECT_URI

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -5,6 +5,7 @@ plugins {
 android {
 	compileSdk 33
 	defaultConfig {
+		manifestPlaceholders = [oAuthScheme:"moshidon-android-auth"]
 		archivesBaseName = "moshidon"
 		applicationId "org.joinmastodon.android.moshinda"
 		minSdk 23
@@ -34,6 +35,7 @@ android {
 			debuggable true
 			versionNameSuffix '-debug'
 			applicationIdSuffix '.debug'
+			manifestPlaceholders = [oAuthScheme:"moshidon-android-debug-auth"]
 		}
 		githubRelease{
 			initWith release
@@ -43,6 +45,7 @@ android {
 			versionNameSuffix '-nightly'
 			applicationIdSuffix '.nightly'
 			signingConfig signingConfigs.nightly
+			manifestPlaceholders = [oAuthScheme:"moshidon-android-nightly-auth"]
 		}
 		playRelease{
 			initWith release

--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
 				<action android:name="android.intent.action.VIEW"/>
 				<category android:name="android.intent.category.BROWSABLE"/>
 				<category android:name="android.intent.category.DEFAULT"/>
-				<data android:scheme="moshidon-android-auth" android:host="callback"/>
+				<data android:scheme="${oAuthScheme}" android:host="callback"/>
 			</intent-filter>
 		</activity>
 		<activity android:name=".ExternalShareActivity" android:exported="true" android:configChanges="orientation|screenSize" android:windowSoftInputMode="adjustResize"

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -65,7 +65,7 @@ import me.grishka.appkit.api.ErrorResponse;
 public class AccountSessionManager{
 	private static final String TAG="AccountSessionManager";
 	public static final String SCOPE="read write follow push";
-	public static final String REDIRECT_URI="moshidon-android-auth://callback";
+	public static final String REDIRECT_URI = getRedirectURI();
 
 	private static final AccountSessionManager instance=new AccountSessionManager();
 
@@ -82,6 +82,17 @@ public class AccountSessionManager{
 
 	public static AccountSessionManager getInstance(){
 		return instance;
+	}
+
+	public static String getRedirectURI() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("moshidon-android-");
+		if (BuildConfig.BUILD_TYPE.equals("debug") || BuildConfig.BUILD_TYPE.equals("nightly")) {
+			builder.append(BuildConfig.BUILD_TYPE);
+			builder.append('-');
+		}
+		builder.append("auth://callback");
+		return builder.toString();
 	}
 
 	private AccountSessionManager(){

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -215,7 +215,7 @@ public class AccountSessionManager{
 								.path("/oauth/authorize")
 								.appendQueryParameter("response_type", "code")
 								.appendQueryParameter("client_id", result.clientId)
-								.appendQueryParameter("redirect_uri", "moshidon-android-auth://callback")
+								.appendQueryParameter("redirect_uri", REDIRECT_URI)
 								.appendQueryParameter("scope", SCOPE)
 								.build();
 


### PR DESCRIPTION
Changes the `REDIRECT_URI` to depend on the `BuildType`. This results in the removal of the app-choose-dialog, which fixes an issue, where the callback would not correctly work when choosing the app.

The GitHub and Play variant still use the old callback, only the debug and nightly Build Types get new callbacks, `moshidon-android-debug-auth` and `moshidon-android-nightly-auth` respectively.