### PR TITLE
Refactor remote follower

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/BaseAccountListFragment.java
@@ -74,6 +74,8 @@ public abstract class BaseAccountListFragment extends RecyclerFragment<BaseAccou
 
 	@Override
 	protected void onDataLoaded(List<AccountItem> d, boolean more){
+		if (getActivity() == null)
+			return;
 		if(refreshing){
 			relationships.clear();
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -9,7 +9,6 @@ import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.HeaderPaginationList;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.Callback;
@@ -27,8 +26,7 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 
 	@Override
 	protected void doLoadData(int offset, int count){
-		if(GlobalUserPreferences.loadRemoteAccountFollowers && targetAccount.getDomain() != null){
-			if ((this instanceof FollowingListFragment || this instanceof FollowerListFragment) && targetAccount != null){
+		if (shouldLoadRemote()) {
 				UiUtils.lookupRemoteAccount(getContext(), targetAccount, accountID, null, account -> {
 					if(account != null){
 						loadRemoteFollower(offset, count, account);
@@ -36,10 +34,16 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 						loadFollower(offset, count);
 					}
 				});
-			}
 		} else {
 			loadFollower(offset, count);
 		}
+	}
+
+	private boolean shouldLoadRemote() {
+		if (!GlobalUserPreferences.loadRemoteAccountFollowers && (this instanceof FollowingListFragment || this instanceof FollowerListFragment)) {
+			return false;
+		}
+		return targetAccount != null && targetAccount.getDomain() != null;
 	}
 
 	void loadFollower(int offset, int count) {

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -27,57 +27,53 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 			if ((this instanceof FollowingListFragment || this instanceof FollowerListFragment) && targetAccount != null){
 				UiUtils.lookupRemoteAccount(getContext(), targetAccount, accountID, null, account -> {
 					if(account != null && account.getDomain() != null){
-						currentRequest=onCreateRemoteRequest(account.id, offset==0 ? null : nextMaxID, count)
-								.setCallback(new SimpleCallback<>(this){
-									@Override
-									public void onSuccess(HeaderPaginationList<Account> result){
-										if(result.nextPageUri!=null)
-											nextMaxID=result.nextPageUri.getQueryParameter("max_id");
-										else
-											nextMaxID=null;
-										result.stream().forEach(remoteAccount -> {
-											remoteAccount.reloadWhenClicked = true;
-											if (remoteAccount.getDomain() == null) {
-												remoteAccount.acct += "@" + Uri.parse(remoteAccount.url).getHost();
-											}
-										});
-										if (getActivity() == null) return;
-										onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), false);
-									}
-								})
-								.execNoAuth(targetAccount.getDomain());
+						loadRemoteFollower(offset, count, account);
 					} else {
-						currentRequest=onCreateRequest(offset==0 ? null : nextMaxID, count)
-								.setCallback(new SimpleCallback<>(this){
-									@Override
-									public void onSuccess(HeaderPaginationList<Account> result){
-										if(result.nextPageUri!=null)
-											nextMaxID=result.nextPageUri.getQueryParameter("max_id");
-										else
-											nextMaxID=null;
-										if (getActivity() == null) return;
-										onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), nextMaxID!=null);
-									}
-								})
-								.exec(accountID);
+						loadFollower(offset, count);
 					}
 				});
 			}
 		} else {
-			currentRequest=onCreateRequest(offset==0 ? null : nextMaxID, count)
-					.setCallback(new SimpleCallback<>(this){
-						@Override
-						public void onSuccess(HeaderPaginationList<Account> result){
-							if(result.nextPageUri!=null)
-								nextMaxID=result.nextPageUri.getQueryParameter("max_id");
-							else
-								nextMaxID=null;
-							if (getActivity() == null) return;
-							onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), nextMaxID!=null);
-						}
-					})
-					.exec(accountID);
+			loadFollower(offset, count);
 		}
+	}
+
+	void loadFollower(int offset, int count) {
+		currentRequest=onCreateRequest(offset==0 ? null : nextMaxID, count)
+				.setCallback(new SimpleCallback<>(this){
+					@Override
+					public void onSuccess(HeaderPaginationList<Account> result){
+						if(result.nextPageUri!=null)
+							nextMaxID=result.nextPageUri.getQueryParameter("max_id");
+						else
+							nextMaxID=null;
+						if (getActivity() == null) return;
+						onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), nextMaxID!=null);
+					}
+				})
+				.exec(accountID);
+	}
+
+	private void loadRemoteFollower(int offset, int count, Account account) {
+		currentRequest=onCreateRemoteRequest(account.id, offset==0 ? null : nextMaxID, count)
+				.setCallback(new SimpleCallback<>(this){
+					@Override
+					public void onSuccess(HeaderPaginationList<Account> result){
+						if(result.nextPageUri!=null)
+							nextMaxID=result.nextPageUri.getQueryParameter("max_id");
+						else
+							nextMaxID=null;
+						result.stream().forEach(remoteAccount -> {
+							remoteAccount.reloadWhenClicked = true;
+							if (remoteAccount.getDomain() == null) {
+								remoteAccount.acct += "@" + Uri.parse(remoteAccount.url).getHost();
+							}
+						});
+						if (getActivity() == null) return;
+						onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), false);
+					}
+				})
+				.execNoAuth(targetAccount.getDomain());
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -1,15 +1,11 @@
 package org.joinmastodon.android.fragments.account_list;
 
-import android.app.VoiceInteractor;
-
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.api.requests.HeaderPaginationRequest;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.model.HeaderPaginationList;
 import org.joinmastodon.android.ui.utils.UiUtils;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import me.grishka.appkit.api.SimpleCallback;
@@ -37,8 +33,8 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 											nextMaxID=result.nextPageUri.getQueryParameter("max_id");
 										else
 											nextMaxID=null;
-										result.stream().forEach(account1 -> {
-											account1.reloadWhenClicked = true;
+										result.stream().forEach(remoteAccount -> {
+											remoteAccount.reloadWhenClicked = true;
 										});
 										if (getActivity() == null) return;
 										onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), false);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -47,7 +47,6 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 							nextMaxID=result.nextPageUri.getQueryParameter("max_id");
 						else
 							nextMaxID=null;
-						if (getActivity() == null) return;
 						onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), nextMaxID!=null);
 					}
 				})
@@ -69,7 +68,6 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 								remoteAccount.acct += "@" + Uri.parse(remoteAccount.url).getHost();
 							}
 						});
-						if (getActivity() == null) return;
 						onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), false);
 					}
 				})

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -1,5 +1,7 @@
 package org.joinmastodon.android.fragments.account_list;
 
+import android.net.Uri;
+
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.api.requests.HeaderPaginationRequest;
 import org.joinmastodon.android.model.Account;
@@ -24,7 +26,7 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 		if(GlobalUserPreferences.loadRemoteAccountFollowers){
 			if ((this instanceof FollowingListFragment || this instanceof FollowerListFragment) && targetAccount != null){
 				UiUtils.lookupRemoteAccount(getContext(), targetAccount, accountID, null, account -> {
-					if(account != null){
+					if(account != null && account.getDomain() != null){
 						currentRequest=onCreateRemoteRequest(account.id, offset==0 ? null : nextMaxID, count)
 								.setCallback(new SimpleCallback<>(this){
 									@Override
@@ -35,6 +37,9 @@ public abstract class PaginatedAccountListFragment extends BaseAccountListFragme
 											nextMaxID=null;
 										result.stream().forEach(remoteAccount -> {
 											remoteAccount.reloadWhenClicked = true;
+											if (remoteAccount.getDomain() == null) {
+												remoteAccount.acct += "@" + Uri.parse(remoteAccount.url).getHost();
+											}
 										});
 										if (getActivity() == null) return;
 										onDataLoaded(result.stream().map(AccountItem::new).collect(Collectors.toList()), false);


### PR DESCRIPTION
Refactor the remote follower code, removing duplication and making it easier to read.
Also fixes a few minor things, like accounts on the home instance not loading, and sets the display of home instance accounts correctly, back to what is was before.