### PR TITLE
fix: compose shortcut contrast

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/SettingsFragment.java
@@ -497,7 +497,7 @@ public class SettingsFragment extends MastodonToolbarFragment{
 		}
 
 		String version = getContext().getString(R.string.mo_settings_app_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE);
-		items.add(new TextItem(version, () -> UiUtils.copyText(view, version)));
+		items.add(new FooterItem(version, () -> UiUtils.copyText(view, version)));
 	}
 
 	private void updatePublishText(Button btn) {
@@ -955,9 +955,11 @@ public class SettingsFragment extends MastodonToolbarFragment{
 
 	private class FooterItem extends Item{
 		private String text;
+		private Runnable onClick;
 
-		public FooterItem(String text){
+		public FooterItem(String text, Runnable onClick){
 			this.text=text;
+			this.onClick=onClick;
 		}
 
 		@Override
@@ -1236,7 +1238,7 @@ public class SettingsFragment extends MastodonToolbarFragment{
 		}
 	}
 
-	private class FooterViewHolder extends BindableViewHolder<FooterItem>{
+	private class FooterViewHolder extends BindableViewHolder<FooterItem> implements UsableRecyclerView.Clickable{
 		private final TextView text;
 		public FooterViewHolder(){
 			super(getActivity(), R.layout.item_settings_footer, list);
@@ -1246,6 +1248,11 @@ public class SettingsFragment extends MastodonToolbarFragment{
 		@Override
 		public void onBind(FooterItem item){
 			text.setText(item.text);
+		}
+
+		@Override
+		public void onClick(){
+			item.onClick.run();
 		}
 	}
 

--- a/mastodon/src/main/res/values/colors.xml
+++ b/mastodon/src/main/res/values/colors.xml
@@ -98,8 +98,8 @@
 	<color name="bookmark_selected">@color/success_500</color>
 	<color name="boost_selected">@color/primary_500</color>
 
-	<color name="shortcut_icon_background">#282C37</color>
-	<color name="shortcut_icon_foreground">@color/purple_primary_700</color>
+	<color name="shortcut_icon_background">@color/gray_25</color>
+	<color name="shortcut_icon_foreground">@color/purple_primary_400</color>
 
 	<!-- M3 dynamic colors -->
 	<color name="m3_navigation_bar_bg">@color/gray_50</color>


### PR DESCRIPTION
Fixes an issue where the compose shortcut had colors with very low contrast between them, making it hard to see.

| Before                                                                                                           	| After                                                                                                           	|
|------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------	|
| ![Before](https://user-images.githubusercontent.com/63370021/233628341-d18ebf13-a437-4e13-847e-85bf58fd8dd4.png) 	| ![After](https://user-images.githubusercontent.com/63370021/233628344-2de6abbe-b03b-4013-b1e3-310a10a871c0.png) 	|