### PR TITLE
feat: hide reblogs count on non-rebloggable status

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
@@ -62,7 +62,7 @@ public class ThreadFragment extends StatusListFragment implements DomainDisplay{
 				else if(item instanceof FooterStatusDisplayItem footer)
 					footer.hideCounts=true;
 			}
-			items.add(new ExtendedFooterStatusDisplayItem(s.id, this, s.getContentStatus()));
+			items.add(new ExtendedFooterStatusDisplayItem(s.id, this, accountID, s.getContentStatus()));
 		}
 		return items;
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonParseException;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.api.ObjectValidationException;
 import org.joinmastodon.android.api.RequiredField;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.events.StatusCountersUpdatedEvent;
 import org.joinmastodon.android.ui.text.HtmlParser;
 import org.parceler.Parcel;
@@ -169,6 +170,11 @@ public class Status extends BaseModel implements DisplayItemsParent, Searchable{
 		if(strippedText==null)
 			strippedText=HtmlParser.strip(content);
 		return strippedText;
+	}
+
+	public boolean canBeBoosted(String accountID){
+		return (visibility==StatusPrivacy.PUBLIC || visibility==StatusPrivacy.UNLISTED || visibility==StatusPrivacy.LOCAL
+					|| (visibility==StatusPrivacy.PRIVATE && account.id.equals(AccountSessionManager.getInstance().getAccount(accountID).self.id)));
 	}
 
 	public static Status ofFake(String id, String text, Instant createdAt) {

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ExtendedFooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ExtendedFooterStatusDisplayItem.java
@@ -14,6 +14,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.fragments.StatusEditHistoryFragment;
 import org.joinmastodon.android.fragments.account_list.StatusFavoritesListFragment;
@@ -34,12 +35,14 @@ import me.grishka.appkit.Nav;
 
 public class ExtendedFooterStatusDisplayItem extends StatusDisplayItem{
 	public final Status status;
+	public final String accountID;
 
 	private static final DateTimeFormatter TIME_FORMATTER=DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.SHORT);
 
-	public ExtendedFooterStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, Status status){
+	public ExtendedFooterStatusDisplayItem(String parentID, BaseStatusListFragment parentFragment, String accountID, Status status){
 		super(parentID, parentFragment);
 		this.status=status;
+		this.accountID=accountID;
 	}
 
 	@Override
@@ -75,7 +78,7 @@ public class ExtendedFooterStatusDisplayItem extends StatusDisplayItem{
 			favorites.setText(context.getResources().getQuantityString(R.plurals.x_favorites, (int)(s.favouritesCount%1000), s.favouritesCount));
 
 			reblogs.setText(context.getResources().getQuantityString(R.plurals.x_reblogs, (int) (s.reblogsCount % 1000), s.reblogsCount));
-			if (s.visibility==StatusPrivacy.DIRECT)
+			if (!s.canBeBoosted(item.accountID))
 				reblogs.setVisibility(View.GONE);
 
 			if(s.editedAt!=null){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
@@ -152,8 +152,7 @@ public class FooterStatusDisplayItem extends StatusDisplayItem{
 			boost.setSelected(item.status.reblogged);
 			favorite.setSelected(item.status.favourited);
 			bookmark.setSelected(item.status.bookmarked);
-			boost.setEnabled(item.status.visibility==StatusPrivacy.PUBLIC || item.status.visibility==StatusPrivacy.UNLISTED || item.status.visibility==StatusPrivacy.LOCAL
-					|| (item.status.visibility==StatusPrivacy.PRIVATE && item.status.account.id.equals(AccountSessionManager.getInstance().getAccount(item.accountID).self.id)));
+			boost.setEnabled(item.status.canBeBoosted(item.accountID));
 
 		}
 


### PR DESCRIPTION
A follow-up to https://github.com/LucasGGamerM/moshidon/pull/174, hiding the `reblogCount` on _all_ private statuses, and not just private ones. As this check is identical to the one for the boost action itself, it has been moved to the status class.