### PR TITLE
Feat: show unfollow confirmation dialog

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -141,7 +141,7 @@ import me.grishka.appkit.utils.V;
 import okhttp3.MediaType;
 
 public class UiUtils {
-	private static Handler mainHandler = new Handler(Looper.getMainLooper());
+	private static final Handler mainHandler = new Handler(Looper.getMainLooper());
 	private static final DateTimeFormatter DATE_FORMATTER_SHORT_WITH_YEAR = DateTimeFormatter.ofPattern("d MMM uuuu"), DATE_FORMATTER_SHORT = DateTimeFormatter.ofPattern("d MMM");
 	public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.SHORT);
 	public static int MAX_WIDTH;
@@ -324,9 +324,8 @@ public class UiUtils {
 
 	public static void loadCustomEmojiInTextView(TextView view){
 		CharSequence _text=view.getText();
-		if(!(_text instanceof Spanned))
+		if(!(_text instanceof Spanned text))
 			return;
-		Spanned text=(Spanned)_text;
 		CustomEmojiSpan[] spans=text.getSpans(0, text.length(), CustomEmojiSpan.class);
 		if(spans.length==0)
 			return;
@@ -760,58 +759,49 @@ public class UiUtils {
 
 	public static void performAccountAction(Activity activity, Account account, String accountID, Relationship relationship, Button button, Consumer<Boolean> progressCallback, Consumer<Relationship> resultCallback) {
 		if(relationship == null){
-			UiUtils.lookupAccount(button.getContext(), account, accountID, null, account1 -> {
-				if(account1 == null){
-					return;
+			UiUtils.lookupAccount(button.getContext(), account, accountID, null, lookUpAccount -> {
+				if (lookUpAccount != null) {
+					progressCallback.accept(true);
+					follow(activity, accountID, lookUpAccount, true, progressCallback, resultCallback);
 				}
-				progressCallback.accept(true);
-				new SetAccountFollowed(account1.id, true, true, false)
-						.setCallback(new Callback<>(){
-							@Override
-							public void onSuccess(Relationship result){
-								resultCallback.accept(result);
-								progressCallback.accept(false);
-								if(!result.following && !result.requested){
-									E.post(new RemoveAccountPostsEvent(accountID, account.id, true));
-								}
-							}
-
-							@Override
-							public void onError(ErrorResponse error){
-								error.showToast(activity);
-								progressCallback.accept(false);
-							}
-						})
-						.exec(accountID);
 			});
 			return;
 		}
+
 		if (relationship.blocking) {
 			confirmToggleBlockUser(activity, accountID, account, true, resultCallback);
-		}else if(relationship.muting){
-			confirmToggleMuteUser(activity, accountID, account, true, resultCallback);
-		}else{
-			progressCallback.accept(true);
-			new SetAccountFollowed(account.id, !relationship.following && !relationship.requested, true, false)
-					.setCallback(new Callback<>(){
-						@Override
-						public void onSuccess(Relationship result){
-							resultCallback.accept(result);
-							progressCallback.accept(false);
-							if(!result.following && !result.requested){
-								E.post(new RemoveAccountPostsEvent(accountID, account.id, true));
-							}
-						}
-
-						@Override
-						public void onError(ErrorResponse error){
-							error.showToast(activity);
-							progressCallback.accept(false);
-						}
-					})
-					.exec(accountID);
+			return;
 		}
+
+		if(relationship.muting){
+			confirmToggleMuteUser(activity, accountID, account, true, resultCallback);
+			return;
+		}
+
+		progressCallback.accept(true);
+		follow(activity, accountID, account,  !relationship.following && !relationship.requested, progressCallback, resultCallback);
+
 	}
+
+	private static void follow(Activity activity, String accountID, Account account, boolean followed, Consumer<Boolean> progressCallback, Consumer<Relationship> resultCallback) {
+		new SetAccountFollowed(account.id, followed, true, false)
+				.setCallback(new Callback<>(){
+					@Override
+					public void onSuccess(Relationship result){
+						resultCallback.accept(result);
+						progressCallback.accept(false);
+						if(!result.following && !result.requested){
+							E.post(new RemoveAccountPostsEvent(accountID, account.id, true));
+						}
+					}
+
+					@Override
+					public void onError(ErrorResponse error){
+						error.showToast(activity);
+						progressCallback.accept(false);
+					}
+				})
+				.exec(accountID);	}
 
 
 	public static void handleFollowRequest(Activity activity, Account account, String accountID, @Nullable String notificationID, boolean accepted, Relationship relationship, Consumer<Relationship> resultCallback) {

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -54,5 +54,6 @@
     <string name="mo_swap_bookmark_with_reblog">Use reblog action instead of bookmark action on notifications</string>
     <string name="mo_download_latest_nightly_release">Download latest nightly release</string>
     <string name="mo_load_remote_followers">Load remote profile follows and followers</string>
-    <string name="mo_mention_reblogger_automatically">Automatically mention account who reblogged the post in replies</string>
+    <string name="mo_confirm_unfollow_title">Unfollow Account</string>
+    <string name="mo_confirm_unfollow">Confirm to unfollow %s</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -54,6 +54,7 @@
     <string name="mo_swap_bookmark_with_reblog">Use reblog action instead of bookmark action on notifications</string>
     <string name="mo_download_latest_nightly_release">Download latest nightly release</string>
     <string name="mo_load_remote_followers">Load remote profile follows and followers</string>
+    <string name="mo_mention_reblogger_automatically">Automatically mention account who reblogged the post in replies</string>
     <string name="mo_confirm_unfollow_title">Unfollow Account</string>
     <string name="mo_confirm_unfollow">Confirm to unfollow %s</string>
 </resources>


### PR DESCRIPTION
Shows a dialog to confirm unfollowing a user. This option is also available on the web client. It is the new default behavior, as it is easier to accidentally click the button on a mobile device than on the web.

I also refactored the  `performAccountAction` method to remove duplicated code.
![Unfollow confirmation dialog](https://github.com/LucasGGamerM/moshidon/assets/63370021/25242451-cedd-4f7a-a7d3-85cf3323580f)
