### PR TITLE
fix(instance-info): hide menu until loaded

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/InstanceInfoFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/InstanceInfoFragment.java
@@ -163,6 +163,7 @@ public class InstanceInfoFragment extends LoaderFragment {
 						instance = result;
 						bindViews();
 						dataLoaded();
+						invalidateOptionsMenu();
 						if(refreshing) {
 							refreshing = false;
 							refreshLayout.setRefreshing(false);
@@ -327,8 +328,10 @@ public class InstanceInfoFragment extends LoaderFragment {
 
 	@Override
 	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater){
-		inflater.inflate(R.menu.instance_info, menu);
-		UiUtils.enableOptionsMenuIcons(getActivity(), menu);
+		if (instance != null) {
+			inflater.inflate(R.menu.instance_info, menu);
+			UiUtils.enableOptionsMenuIcons(getActivity(), menu);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This hides the menu until then instance is loaded. This is done, so it is no longer possible to visit pages in the menu, as they relied on the instance being loaded and will crash the app otherwise.