### PR TITLE
feat: Add haptics compatibility for APIs 23-29

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -140,7 +140,7 @@ public class GlobalUserPreferences{
 		replyLineAboveHeader=prefs.getBoolean("replyLineAboveHeader", true);
 		compactReblogReplyLine=prefs.getBoolean("compactReblogReplyLine", true);
 		confirmBeforeReblog=prefs.getBoolean("confirmBeforeReblog", false);
-		hapticFeedback=prefs.getBoolean("hapticFeedback", Build.VERSION.SDK_INT >= Build.VERSION_CODES.R);
+		hapticFeedback=prefs.getBoolean("hapticFeedback", true);
 		swapBookmarkWithBoostAction=prefs.getBoolean("swapBookmarkWithBoostAction", false);
 		loadRemoteAccountFollowers=prefs.getBoolean("loadRemoteAccountFollowers", true);
 		mentionRebloggerAutomatically=prefs.getBoolean("mentionRebloggerAutomatically", false);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/BehaviourFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/BehaviourFragment.java
@@ -67,7 +67,7 @@ public class BehaviourFragment extends SettingsBaseFragment{
         items.add(new SwitchItem(R.string.mo_haptic_feedback, R.string.mo_setting_haptic_feedback_summary, R.drawable.ic_fluent_phone_vibrate_24_filled, GlobalUserPreferences.hapticFeedback, i -> {
             GlobalUserPreferences.hapticFeedback = i.checked;
             GlobalUserPreferences.save();
-        }, Build.VERSION.SDK_INT >= Build.VERSION_CODES.R));
+        }));
         items.add(new SwitchItem(R.string.sk_settings_confirm_before_reblog, R.drawable.ic_fluent_checkmark_circle_24_regular, GlobalUserPreferences.confirmBeforeReblog, i->{
             GlobalUserPreferences.confirmBeforeReblog=i.checked;
             GlobalUserPreferences.save();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBaseFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBaseFragment.java
@@ -264,15 +264,6 @@ public abstract class SettingsBaseFragment extends MastodonToolbarFragment imple
 			this.onChanged=onChanged;
 		}
 
-		public SwitchItem(@StringRes int title, @StringRes int summary, @DrawableRes int icon, boolean checked, Consumer<SwitchItem> onChanged, boolean enabled){
-			this.title=getString(title);
-			this.summary=getString(summary);
-			this.icon=icon;
-			this.checked=checked;
-			this.onChanged=onChanged;
-			this.enabled=enabled;
-		}
-
 		public SwitchItem(@StringRes int title, @DrawableRes int icon, boolean checked, Consumer<SwitchItem> onChanged, boolean enabled){
 			this.title=getString(title);
 			this.icon=icon;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
@@ -7,6 +7,8 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
 import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -470,8 +472,24 @@ public class FooterStatusDisplayItem extends StatusDisplayItem{
 
 		private static void vibrateForAction(View view, boolean isPositive) {
 			if (!GlobalUserPreferences.hapticFeedback) return;
-			if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return;
-			view.performHapticFeedback(isPositive ? HapticFeedbackConstants.CONFIRM : HapticFeedbackConstants.REJECT);
+
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+				view.performHapticFeedback(isPositive ? HapticFeedbackConstants.CONFIRM : HapticFeedbackConstants.REJECT);
+			} else {
+				Vibrator vibrator = view.getContext().getSystemService(Vibrator.class);
+
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+					vibrator.vibrate(VibrationEffect.createPredefined(isPositive ? VibrationEffect.EFFECT_CLICK : VibrationEffect.EFFECT_DOUBLE_CLICK));
+				} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+					VibrationEffect effect = isPositive
+						? VibrationEffect.createOneShot(75L, 128)
+						: VibrationEffect.createWaveform(new long[]{0L, 75L, 75L, 75L}, new int[]{0, 128, 0, 128}, -1);
+					vibrator.vibrate(effect);
+				} else {
+					if (isPositive) vibrator.vibrate(75L);
+					else vibrator.vibrate(new long[]{0L, 75L, 75L, 75L}, -1);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds backwards compatibility for the new haptics feature from #214. Since this is an area of the Android API that has changed quite a lot recently, the appropriate API is used at each level. All API levels should be supported by it now.