### PR TITLE
fix: small nord theme improvements

### DIFF
--- a/mastodon/src/main/res/color/favorite_icon.xml
+++ b/mastodon/src/main/res/color/favorite_icon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-	<item android:color="?favorite_selected" android:state_selected="true"/>
+	<item android:color="?colorFavorite" android:state_selected="true"/>
 	<item android:color="?android:textColorSecondary"/>
 </selector>

--- a/mastodon/src/main/res/values/attrs.xml
+++ b/mastodon/src/main/res/values/attrs.xml
@@ -100,7 +100,6 @@
 	<attr name="colorNeutral900" format="color" />
 
 	<attr name="bookmark_selected" format="color" />
-	<attr name="favorite_selected" format="color" />
 
 	<declare-styleable name="MaxWidthFrameLayout">
 		<attr name="android:maxWidth" format="dimension"/>

--- a/mastodon/src/main/res/values/colors.xml
+++ b/mastodon/src/main/res/values/colors.xml
@@ -348,7 +348,7 @@
 	<color name="nord_primary_800">#3b4252</color>
 	<color name="nord_primary_900">#2e3440</color>
 
-	<color name="nord_gray_900">#3B4252</color>
+	<color name="nord_gray_900">#2e3440</color>
 <!--	<color name="nord_gray_800t">#cc2D343F</color>-->
 	<color name="nord_gray_800">#2D343F</color>
 	<color name="nord_gray_700">#3A4250</color>

--- a/mastodon/src/main/res/values/colors.xml
+++ b/mastodon/src/main/res/values/colors.xml
@@ -93,7 +93,6 @@
 	<color name="navigation_bar_bg_light">#282C37</color>
 	<color name="highlight_over_dark">#30FFFFFF</color>
 
-	<color name="favorite_selected">@color/warning_500</color>
 	<color name="bookmark_selected">@color/success_500</color>
 
 	<color name="shortcut_icon_background">@color/gray_25</color>
@@ -339,7 +338,7 @@
 	<color name="nord_primary_25">#fafaff</color>
 	<color name="nord_primary_50">#eff0ff</color>
 	<color name="nord_primary_100">#eceff4</color>
-	<color name="nord_primary_200">#e5e9f0</color>
+	<color name="nord_primary_200">#88c0d0</color>
 	<color name="nord_primary_300">#d8dee9</color>
 	<color name="nord_primary_400">#88c0d0</color>
 	<color name="nord_primary_500">#4c566a</color>
@@ -355,7 +354,7 @@
 	<color name="nord_gray_600">#404C5C</color>
 	<color name="nord_gray_500">#aa8C96B4</color>
 
-	<color name="nord_favorite_selected">#ebcb8b</color>
+	<color name="nord_favorite">#ebcb8b</color>
 	<color name="nord_bookmark_selected">#a3be8c</color>
 
 <!--	<color name="nord_gray_400t">#4d8C96B4</color>-->

--- a/mastodon/src/main/res/values/palettes.xml
+++ b/mastodon/src/main/res/values/palettes.xml
@@ -13,7 +13,6 @@
 		<item name="colorPrimary800">@color/primary_800</item>
 		<item name="colorPrimary900">@color/primary_900</item>
 		<item name="bookmark_selected">@color/bookmark_selected</item>
-		<item name="favorite_selected">@color/favorite_selected</item>
 
 		<item name="colorGray900">@color/gray_900</item>
 		<item name="colorGray800">@color/gray_800</item>
@@ -56,7 +55,7 @@
 		<item name="colorM3DarkOnSurface">?colorGray100</item>
 		<item name="colorM3PrimaryInverse">?colorPrimary200</item>
 
-		<item name="colorFavorite">@color/favorite_selected</item>
+		<item name="colorFavorite">@color/warning_500</item>
 		<item name="colorBoost">?colorM3Primary</item>
 		<item name="colorPoll">@color/bookmark_selected</item>
 		<item name="colorTabBarAlpha">#14000000</item>
@@ -454,7 +453,7 @@
 		<item name="colorPrimary900">@color/nord_primary_900</item>
 
 		<item name="bookmark_selected">@color/nord_bookmark_selected</item>
-		<item name="favorite_selected">@color/nord_favorite_selected</item>
+		<item name="colorFavorite">@color/nord_favorite</item>
 
 		<item name="colorGray900">@color/nord_gray_900</item>
 <!--		<item name="colorGray800t">@color/nord_gray_800t</item>-->


### PR DESCRIPTION
Minor fixes to the Nord theme. It still needs further fixes (menus have the wrong tint, compose hint looks like text), but at least the rest is more recognizable now.

Additionally, removes the `favorite_selected` color, as it has been replaced upstream by `colorFavorite`.