### PR TITLE
fix: allow long version names

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsAboutAppFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsAboutAppFragment.java
@@ -51,7 +51,6 @@ public class SettingsAboutAppFragment extends BaseSettingsFragment<Void>{
 		adapter.addAdapter(super.getAdapter());
 
 		TextView versionInfo=new TextView(getActivity());
-		versionInfo.setSingleLine();
 		versionInfo.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, V.dp(32)));
 		versionInfo.setTextAppearance(R.style.m3_label_medium);
 		versionInfo.setTextColor(UiUtils.getThemeColor(getActivity(), R.attr.colorM3Outline));


### PR DESCRIPTION
Allows the version name to be shown over multiple lines, as it can be quite long, especially for nightly builds.

| Before                                                                                                                             	| After                                                                                                                         	|
|------------------------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------	|
| ![Version name over multiple lines](https://github.com/LucasGGamerM/moshidon/assets/63370021/2956e76e-f4be-4368-8fbd-b5019af0840d) 	| ![Version name on single line](https://github.com/LucasGGamerM/moshidon/assets/63370021/69f458b8-2b3b-4811-9c63-d977cd7c6383) 	|