### PR TITLE
fix(theme/fav-color): set default color in fallback

### DIFF
--- a/mastodon/src/main/res/values/palettes.xml
+++ b/mastodon/src/main/res/values/palettes.xml
@@ -13,6 +13,7 @@
 		<item name="colorPrimary800">@color/primary_800</item>
 		<item name="colorPrimary900">@color/primary_900</item>
 		<item name="colorBookmark">@color/bookmark_selected</item>
+		<item name="colorFavorite">@color/warning_500</item>
 
 		<item name="colorGray900">@color/gray_900</item>
 		<item name="colorGray800">@color/gray_800</item>
@@ -55,7 +56,6 @@
 		<item name="colorM3DarkOnSurface">?colorGray100</item>
 		<item name="colorM3PrimaryInverse">?colorPrimary200</item>
 
-		<item name="colorFavorite">@color/warning_500</item>
 		<item name="colorBoost">?colorM3Primary</item>
 		<item name="colorPoll">@color/bookmark_selected</item>
 		<item name="colorTabBarAlpha">#14000000</item>


### PR DESCRIPTION
Fixes a regression in 2a7d7d2, which set the fav color for all themes, including ones that overwrite it.