### PR TITLE
feat: allow doubleTapToSwipe when doubleTapToSearch is disabled

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -66,6 +66,7 @@ public class GlobalUserPreferences{
 	public static boolean showDividers;
 	public static boolean relocatePublishButton;
 	public static boolean defaultToUnlistedReplies;
+	public static boolean doubleTapToSearch;
 	public static boolean doubleTapToSwipe;
 	public static boolean confirmBeforeReblog;
 	public static boolean hapticFeedback;
@@ -140,6 +141,7 @@ public class GlobalUserPreferences{
 		relocatePublishButton=prefs.getBoolean("relocatePublishButton", true);
 		compactReblogReplyLine=prefs.getBoolean("compactReblogReplyLine", true);
 		defaultToUnlistedReplies=prefs.getBoolean("defaultToUnlistedReplies", false);
+		doubleTapToSearch =prefs.getBoolean("doubleTapToSearch", true);
 		doubleTapToSwipe =prefs.getBoolean("doubleTapToSwipe", true);
 		replyLineAboveHeader=prefs.getBoolean("replyLineAboveHeader", true);
 		confirmBeforeReblog=prefs.getBoolean("confirmBeforeReblog", false);
@@ -216,6 +218,7 @@ public class GlobalUserPreferences{
 
 				// MOSHIDON
 				.putBoolean("defaultToUnlistedReplies", defaultToUnlistedReplies)
+				.putBoolean("doubleTapToSearch", doubleTapToSearch)
 				.putBoolean("doubleTapToSwipe", doubleTapToSwipe)
 				.putBoolean("compactReblogReplyLine", compactReblogReplyLine)
 				.putBoolean("replyLineAboveHeader", replyLineAboveHeader)

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -309,13 +309,13 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			return true;
 		}
 		if(tab==R.id.tab_search){
-			//int previousTab = currentTab;
+//			int previousTab = currentTab;
 
 			onTabSelected(R.id.tab_search);
 			tabBar.selectTab(R.id.tab_search);
 
-			//if(previousTab != R.id.tab_search)
-			discoverFragment.openSearch();
+			if(!GlobalUserPreferences.doubleTapToSearch)
+				discoverFragment.openSearch();
 
 			return true;
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -309,13 +309,13 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			return true;
 		}
 		if(tab==R.id.tab_search){
-			int previousTab = currentTab;
+			//int previousTab = currentTab;
 
 			onTabSelected(R.id.tab_search);
 			tabBar.selectTab(R.id.tab_search);
 
-			if(previousTab != R.id.tab_search)
-				discoverFragment.openSearch();
+			//if(previousTab != R.id.tab_search)
+			discoverFragment.openSearch();
 
 			return true;
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -269,7 +269,7 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 	private void onTabSelected(@IdRes int tab){
 		Fragment newFragment=fragmentForTab(tab);
 		if(tab==currentTab){
-			if (tab == R.id.tab_search)
+			if (tab == R.id.tab_search && GlobalUserPreferences.doubleTapToSearch)
 				discoverFragment.openSearch();
 			else if(newFragment instanceof ScrollableToTop scrollable)
 				scrollable.scrollToTop();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -12,6 +12,7 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
@@ -208,6 +209,11 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 	@Override
 	public void scrollToTop(){
 		if(!searchActive){
+			if (((IsOnTop)getFragmentForPage(pager.getCurrentItem())).isOnTop() && GlobalUserPreferences.doubleTapToSwipe){
+				int nextPage=(pager.getCurrentItem()+1)%tabViews.length;
+				pager.setCurrentItem(nextPage, true);
+				return;
+			}
 			((ScrollableToTop)getFragmentForPage(pager.getCurrentItem())).scrollToTop();
 		}else{
 			searchFragment.scrollToTop();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.trends.GetTrendingLinks;
+import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
 import org.joinmastodon.android.model.Card;
 import org.joinmastodon.android.model.viewmodel.CardViewModel;
@@ -43,7 +44,7 @@ import me.grishka.appkit.utils.SingleViewRecyclerAdapter;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class DiscoverNewsFragment extends BaseRecyclerFragment<CardViewModel> implements ScrollableToTop{
+public class DiscoverNewsFragment extends BaseRecyclerFragment<CardViewModel> implements ScrollableToTop, IsOnTop{
 	private String accountID;
 	private DiscoverInfoBannerHelper bannerHelper;
 	private MergeRecyclerAdapter mergeAdapter;
@@ -109,6 +110,11 @@ public class DiscoverNewsFragment extends BaseRecyclerFragment<CardViewModel> im
 	@Override
 	public void scrollToTop(){
 		smoothScrollRecyclerViewToTop(list);
+	}
+
+	@Override
+	public boolean isOnTop(){
+		return isRecyclerViewOnTop(list);
 	}
 
 	private class LinksAdapter extends UsableRecyclerView.Adapter<BaseLinkViewHolder> implements ImageLoaderRecyclerAdapter{

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.trends.GetTrendingHashtags;
+import org.joinmastodon.android.fragments.IsOnTop;
 import org.joinmastodon.android.fragments.ScrollableToTop;
 import org.joinmastodon.android.model.Hashtag;
 import org.joinmastodon.android.ui.DividerItemDecoration;
@@ -23,7 +24,7 @@ import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> implements ScrollableToTop{
+public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop{
 	private String accountID;
 
 	public TrendingHashtagsFragment(){
@@ -56,6 +57,11 @@ public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> impl
 	@Override
 	public void scrollToTop(){
 		smoothScrollRecyclerViewToTop(list);
+	}
+
+	@Override
+	public boolean isOnTop(){
+		return isRecyclerViewOnTop(list);
 	}
 
 	private class HashtagsAdapter extends RecyclerView.Adapter<HashtagViewHolder>{

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsDisplayFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsDisplayFragment.java
@@ -43,7 +43,7 @@ public class SettingsDisplayFragment extends BaseSettingsFragment<Void>{
 	private CheckableListItem<Void> pronounsInUserListingsItem, pronounsInTimelinesItem, pronounsInThreadsItem;
 
 	// MOSHIDON
-	private  CheckableListItem<Void> enableDoubleTapToSwipeItem, relocatePublishButtonItem, showPostDividersItem;
+	private  CheckableListItem<Void> enableDoubleTapToSwipeItem, relocatePublishButtonItem, showPostDividersItem, enableDoubleTapToSearchItem;
 
 	private AccountLocalPreferences lp;
 
@@ -66,6 +66,7 @@ public class SettingsDisplayFragment extends BaseSettingsFragment<Void>{
 				emojiInNamesItem=new CheckableListItem<>(R.string.settings_show_emoji_in_names, 0, CheckableListItem.Style.SWITCH, lp.customEmojiInNames, R.drawable.ic_fluent_emoji_24_regular, ()->toggleCheckableItem(emojiInNamesItem)),
 				marqueeItem=new CheckableListItem<>(R.string.sk_settings_enable_marquee, R.string.mo_setting_marquee_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.toolbarMarquee, R.drawable.ic_fluent_text_more_24_regular, ()->toggleCheckableItem(marqueeItem)),
 				reduceMotionItem=new CheckableListItem<>(R.string.sk_settings_reduce_motion, R.string.mo_setting_reduced_motion_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.reduceMotion, R.drawable.ic_fluent_star_emphasis_24_regular, ()->toggleCheckableItem(reduceMotionItem)),
+				enableDoubleTapToSearchItem=new CheckableListItem<>(R.string.mo_double_tap_to_search, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.doubleTapToSearch, R.drawable.ic_fluent_search_24_regular, ()->toggleCheckableItem(enableDoubleTapToSearchItem)),
 				disableSwipeItem=new CheckableListItem<>(R.string.sk_settings_tabs_disable_swipe, R.string.mo_setting_disable_swipe_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.disableSwipe, R.drawable.ic_fluent_swipe_right_24_regular, ()->toggleCheckableItem(disableSwipeItem)),
 				enableDoubleTapToSwipeItem=new CheckableListItem<>(R.string.mo_double_tap_to_swipe_between_tabs, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.doubleTapToSwipe, R.drawable.ic_fluent_double_tap_swipe_right_24_regular, ()->toggleCheckableItem(enableDoubleTapToSwipeItem)),
 				altIndicatorItem=new CheckableListItem<>(R.string.sk_settings_show_alt_indicator, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.showAltIndicator, R.drawable.ic_fluent_scan_text_24_regular, ()->toggleCheckableItem(altIndicatorItem)),
@@ -114,6 +115,7 @@ public class SettingsDisplayFragment extends BaseSettingsFragment<Void>{
 		GlobalUserPreferences.relocatePublishButton=relocatePublishButtonItem.checked;
 		GlobalUserPreferences.reduceMotion=reduceMotionItem.checked;
 		GlobalUserPreferences.disableSwipe=disableSwipeItem.checked;
+		GlobalUserPreferences.doubleTapToSearch=enableDoubleTapToSearchItem.checked;
 		GlobalUserPreferences.doubleTapToSwipe=enableDoubleTapToSwipeItem.checked;
 		GlobalUserPreferences.showAltIndicator=altIndicatorItem.checked;
 		GlobalUserPreferences.showNoAltIndicator=noAltIndicatorItem.checked;

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -87,6 +87,7 @@
 <!--  Settings  -->
     <string name="mo_notification_audience_settings">Notification Audience</string>
     <string name="mo_settings_show_posts_without_alt">Show media posts with missing alt text</string>
+	<string name="mo_double_tap_to_search">Double tap to open search</string>
 	<string name="mo_double_tap_to_swipe_between_tabs">Double tap to swipe between tabs</string>
 	<string name="mo_haptic_feedback">Haptic feedback</string>
 	<string name="mo_swap_bookmark_with_reblog">Swap bookmark with reblog action</string>


### PR DESCRIPTION
Extends the functionality of https://github.com/LucasGGamerM/moshidon/pull/124.

Adds a new option to enable/disable the doubleTapToSearch behavior.

If it is disabled, allow for double tapping the Discover tab, to cycle through the Discover tabs.

Also changes the upstream longTap to open search to always open the search, regardless of what tab is currently selected.