### PR TITLE
fix: update timeline when showMediaPreview changes

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsDisplayFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsDisplayFragment.java
@@ -106,6 +106,7 @@ public class SettingsDisplayFragment extends BaseSettingsFragment<Void>{
 		boolean restartPlease=
 				GlobalUserPreferences.disableM3PillActiveIndicator!=disablePillItem.checked ||
 				GlobalUserPreferences.showNavigationLabels!=showNavigationLabelsItem.checked ||
+				GlobalUserPreferences.showMediaPreview !=showMediaPreviewItem.checked ||
 				GlobalUserPreferences.showDividers!=showPostDividersItem.checked;
 
 		lp.revealCWs=revealCWsItem.checked;


### PR DESCRIPTION
Fixes an issue, where the timelines were not updated when the Show Media preview setting changed. This could lead to situations where media previews were still shown, even when just disabled.