### PR TITLE
feat: add option to mute hashtag

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -13,17 +13,23 @@ import android.widget.Toast;
 
 import org.joinmastodon.android.E;
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.api.requests.filters.GetFilters;
 import org.joinmastodon.android.api.requests.tags.GetHashtag;
 import org.joinmastodon.android.api.requests.tags.SetHashtagFollowed;
 import org.joinmastodon.android.api.requests.timelines.GetHashtagTimeline;
 import org.joinmastodon.android.events.HashtagUpdatedEvent;
+import org.joinmastodon.android.fragments.settings.EditFilterFragment;
+import org.joinmastodon.android.model.Filter;
 import org.joinmastodon.android.model.FilterContext;
+import org.joinmastodon.android.model.FilterKeyword;
 import org.joinmastodon.android.model.Hashtag;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.model.TimelineDefinition;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.utils.StatusFilterPredicate;
+import org.parceler.Parcels;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -116,6 +122,14 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment {
 				}
 			}).exec(accountID);
 			return true;
+		} else if (item.getItemId() == R.id.mute_hashtag) {
+			Bundle args=new Bundle();
+			args.putString("account", accountID);
+			FilterKeyword hashtagFilter=new FilterKeyword();
+			hashtagFilter.wholeWord=true;
+			hashtagFilter.keyword=hashtag;
+			args.putParcelableArrayList("words", new ArrayList<>(List.of(Parcels.wrap(hashtagFilter))));
+			Nav.go(getActivity(), EditFilterFragment.class, args);
 		}
 		return false;
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -172,7 +172,7 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment {
 	private void muteHashtag() {
 		FilterKeyword hashtagFilter=new FilterKeyword();
 		hashtagFilter.wholeWord=true;
-		hashtagFilter.keyword=hashtag;
+		hashtagFilter.keyword="#"+hashtag;
 		new CreateFilter("#"+hashtag, EnumSet.of(FilterContext.HOME), FilterAction.HIDE, 0 , List.of(hashtagFilter)).setCallback(new Callback<Filter>(){
 			@Override
 			public void onSuccess(Filter result){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/EditFilterFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/EditFilterFragment.java
@@ -68,6 +68,10 @@ public class EditFilterFragment extends BaseSettingsFragment<Void> implements On
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
 		filter=Parcels.unwrap(getArguments().getParcelable("filter"));
+		ArrayList<Parcelable> words=getArguments().getParcelableArrayList("words");
+		if (words != null) {
+				words.stream().map(p->(FilterKeyword)Parcels.unwrap(p)).forEach(keywords::add);
+		}
 		setTitle(filter==null ? R.string.settings_add_filter : R.string.settings_edit_filter);
 		onDataLoaded(List.of(
 				durationItem=new ListItem<>(R.string.settings_filter_duration, 0, this::onDurationClick),

--- a/mastodon/src/main/res/menu/hashtag_timeline.xml
+++ b/mastodon/src/main/res/menu/hashtag_timeline.xml
@@ -10,4 +10,8 @@
         android:icon="@drawable/ic_fluent_person_add_24_regular"
         android:showAsAction="always"
         android:title="@string/button_follow"/>
+	<item
+        android:id="@+id/mute_hashtag"
+        android:icon="@drawable/ic_fluent_speaker_mute_24_regular"
+        android:title="@string/mo_mute_hashtag"/>
 </menu>

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -43,7 +43,11 @@
 	<string name="mo_unmute_conversation">Unmute conversation</string>
 	<string name="mo_confirm_to_mute_conversation">Are you sure you want to mute this conversation?</string>
 	<string name="mo_confirm_to_unmute_conversation">Are you sure you want to unmute this conversation?</string>
-    
+	<string name="mo_mute_hashtag">Mute hashtag</string>
+	<string name="mo_unmute_hashtag">Unmute hashtag</string>
+	<string name="mo_confirm_to_mute_hashtag">Are you sure you want to mute this hashtag?</string>
+	<string name="mo_confirm_to_unmute_hashtag">Are you sure you want to unmute this hashtag?</string>
+
     <!--    accessibility labels-->
     <string name="mo_poll_option_add">Add new poll option</string>
     <string name="mo_fab_compose">Compose</string>
@@ -107,6 +111,4 @@
 	<string name="mo_recent_emoji_cleared">Recent emoji cleared</string>
 	<string name="mo_show_media_preview">Show media preview in timelines</string>
 
-
-	<string name="mo_mute_hashtag">Mute Hashtag</string>
 </resources>

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -106,4 +106,7 @@
 	<string name="mo_confirm_unfollow">Confirm to unfollow %s</string>
 	<string name="mo_recent_emoji_cleared">Recent emoji cleared</string>
 	<string name="mo_show_media_preview">Show media preview in timelines</string>
+
+
+	<string name="mo_mute_hashtag">Mute Hashtag</string>
 </resources>


### PR DESCRIPTION
Closes https://github.com/LucasGGamerM/moshidon/issues/260 by adding the option to mute (create a filter) the hashtag.
This is marked as a draft because there are still some open questions, namely how the UI should handle hashtags that are already muted:
- Do nothing 
- Hide the mute option
- Show an unmute option

In the last two cases, the app has to query and iterate through the filters, as there is no native API to check if a hashtag is muted.

https://github.com/LucasGGamerM/moshidon/assets/63370021/e645f61f-657e-42b8-b82e-3b36d9ebd228