### PR TITLE
Fix for excessive post highlighting when slow-scrolling

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/views/MoshidonUsableRecyclerView.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/views/MoshidonUsableRecyclerView.java
@@ -1,0 +1,68 @@
+package org.joinmastodon.android.ui.views;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.DrawableWrapper;
+import android.util.AttributeSet;
+import android.view.ViewConfiguration;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import me.grishka.appkit.views.UsableRecyclerView;
+
+public class MoshidonUsableRecyclerView extends UsableRecyclerView {
+
+	public MoshidonUsableRecyclerView(Context context){
+		super(context);
+		overrideDefaultSelector();
+	}
+
+	public MoshidonUsableRecyclerView(Context context, AttributeSet attrs){
+		super(context, attrs);
+		overrideDefaultSelector();
+	}
+
+	public MoshidonUsableRecyclerView(Context context, AttributeSet attrs, int defStyle){
+		super(context, attrs, defStyle);
+		overrideDefaultSelector();
+	}
+
+	private void overrideDefaultSelector() {
+		TypedArray ta = this.getContext().obtainStyledAttributes(new int[]{android.R.attr.selectableItemBackground});
+		Drawable selectableDrawable = ta.getDrawable(0);
+		ta.recycle();
+
+		setSelector(new SelectorWrapper(selectableDrawable));
+	}
+
+	private class SelectorWrapper extends DrawableWrapper {
+
+		public SelectorWrapper(@Nullable Drawable drawable){
+			super(drawable);
+		}
+
+		private Runnable scheduledStateChange;
+
+		private long pressedTimestamp = 0L;
+
+		@Override
+		protected boolean onStateChange(@NonNull int[] state){
+			removeCallbacks(scheduledStateChange);
+
+			if (state == PRESSED_ENABLED_FOCUSED_STATE_SET) {
+				pressedTimestamp = System.currentTimeMillis();
+				scheduledStateChange = () -> super.onStateChange(state);
+				postDelayed(scheduledStateChange, 250L);
+				return false;
+			} else {
+				if (System.currentTimeMillis() - pressedTimestamp <= ViewConfiguration.getTapTimeout()) {
+					pressedTimestamp = 0L;
+					super.onStateChange(PRESSED_ENABLED_FOCUSED_STATE_SET);
+				}
+				scheduledStateChange = () -> {};
+				return super.onStateChange(state);
+			}
+		}
+	}
+}

--- a/mastodon/src/main/res/layout/fragment_content_report_posts.xml
+++ b/mastodon/src/main/res/layout/fragment_content_report_posts.xml
@@ -4,7 +4,7 @@
 	android:id="@+id/content_wrap"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
-	<me.grishka.appkit.views.UsableRecyclerView
+	<org.joinmastodon.android.ui.views.MoshidonUsableRecyclerView
 		android:id="@+id/list"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"

--- a/mastodon/src/main/res/layout/fragment_onboarding_rules.xml
+++ b/mastodon/src/main/res/layout/fragment_onboarding_rules.xml
@@ -4,7 +4,7 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
 
-	<me.grishka.appkit.views.UsableRecyclerView
+	<org.joinmastodon.android.ui.views.MoshidonUsableRecyclerView
 		android:id="@+id/list"
 		android:layout_width="match_parent"
 		android:layout_height="0dp"

--- a/mastodon/src/main/res/layout/fragment_profile_about.xml
+++ b/mastodon/src/main/res/layout/fragment_profile_about.xml
@@ -44,7 +44,7 @@
 
     </FrameLayout>
 
-    <me.grishka.appkit.views.UsableRecyclerView
+    <org.joinmastodon.android.ui.views.MoshidonUsableRecyclerView
         android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/mastodon/src/main/res/layout/fragment_report_choice.xml
+++ b/mastodon/src/main/res/layout/fragment_report_choice.xml
@@ -13,7 +13,7 @@
 		android:max="100"
 		android:progressDrawable="@drawable/m3_progress"/>
 
-	<me.grishka.appkit.views.UsableRecyclerView
+	<org.joinmastodon.android.ui.views.MoshidonUsableRecyclerView
 		android:id="@+id/list"
 		android:layout_width="match_parent"
 		android:layout_height="0dp"

--- a/mastodon/src/main/res/layout/recycler_fragment_no_refresh.xml
+++ b/mastodon/src/main/res/layout/recycler_fragment_no_refresh.xml
@@ -3,7 +3,7 @@
 	android:id="@+id/content_wrap"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
-	<me.grishka.appkit.views.UsableRecyclerView
+	<org.joinmastodon.android.ui.views.MoshidonUsableRecyclerView
 		android:id="@+id/list"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"

--- a/mastodon/src/main/res/layout/recycler_fragment_with_fab.xml
+++ b/mastodon/src/main/res/layout/recycler_fragment_with_fab.xml
@@ -8,7 +8,7 @@
 		android:id="@+id/content_wrap"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent">
-		<me.grishka.appkit.views.UsableRecyclerView
+		<org.joinmastodon.android.ui.views.MoshidonUsableRecyclerView
 			android:id="@+id/list"
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"


### PR DESCRIPTION
### Problem
When user is slow-scrolling (keeps finger unmoved during some milliseconds), there are ripple highlight starts (when there is no tap, just scroll). All logic based inside the AppKit and leaves no possibilities for external control.

### Fix
I created `MoshidonUsableRecyclerView` with overriden default selector by putting it in `SelectorWrapper` that provides additional delay before highlight starts.
Also I switch on `MoshidonUsableRecyclerView` usage instead of base `UsableRecyclerView` with each @id/list.
Also so good this class does not interfere with `GestureDetector`, setting custom selector (including null) or `onTouchEvent` dispatching.

(You can change RecyclerView name if you want)