### PR TITLE
Fix poll fraction calculation for Pleroma

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
@@ -40,7 +40,7 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 		text=HtmlParser.parseCustomEmoji(option.title, poll.emojis);
 		emojiHelper.setText(text);
 		showResults=poll.isExpired() || poll.voted;
-		int total=poll.votersCount>0 ? poll.votersCount : poll.votesCount;
+		int total=poll.votesCount;
 		if(showResults && option.votesCount!=null && total>0){
 			votesFraction=(float)option.votesCount/(float)total;
 			int mostVotedCount=0;


### PR DESCRIPTION
I don't know why, but Pleroma reterns `poll.votersCount` equals `1` for polls. So just use `poll.votesCount` as total value for fraction calculation.