### PR TITLE
fix(notification): allow clicking on status item to open profile

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/NotificationHeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/NotificationHeaderStatusDisplayItem.java
@@ -132,8 +132,7 @@ public class NotificationHeaderStatusDisplayItem extends StatusDisplayItem{
 				}
 			}));
 
-			icon.setOnClickListener(this::onItemClick);
-			avatar.setOnClickListener(this::onItemClick);
+			itemView.setOnClickListener(this::onItemClick);
 		}
 
 		@Override


### PR DESCRIPTION
Fixes a regression in 7b4be83781259ad8edf0c05eb6b304aa175201a2, by allowing to click on the entire item view, not just the avatar. This is helpful for accessibility and prevents accidental mis-clicks, and the avatar is a small touch target. The previous behavior of opening the post is maintained when clicking on the postcard below.