### PR TITLE
feat(settings): move unlisted replies to privacy page

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
@@ -34,7 +34,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 	private CheckableListItem<Void> forwardReportsItem, remoteLoadingItem, showBoostsItem, showRepliesItem, loadNewPostsItem, seeNewPostsBtnItem, overlayMediaItem;
 
 	// MOSHIDON
-    private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, hapticFeedbackItem, unlistedRepliesItem, showPostsWithoutAltItem;
+    private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, hapticFeedbackItem, showPostsWithoutAltItem;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -52,7 +52,6 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 				altTextItem=new CheckableListItem<>(R.string.settings_alt_text_reminders, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.altTextReminders, R.drawable.ic_fluent_image_alt_text_24_regular, i->toggleCheckableItem(altTextItem)),
 				showPostsWithoutAltItem=new CheckableListItem<>(R.string.mo_settings_show_posts_without_alt, R.string.mo_settings_show_posts_without_alt_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.showPostsWithoutAlt, R.drawable.ic_fluent_eye_tracking_on_24_regular, i->toggleCheckableItem(showPostsWithoutAltItem)),
 				playGifsItem=new CheckableListItem<>(R.string.settings_gif, R.string.mo_setting_play_gif_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.playGifs, R.drawable.ic_fluent_gif_24_regular, i->toggleCheckableItem(playGifsItem)),
-				unlistedRepliesItem=new CheckableListItem<>(R.string.mo_change_default_reply_visibility_to_unlisted, R.string.mo_setting_default_reply_privacy_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.defaultToUnlistedReplies, R.drawable.ic_fluent_lock_open_24_regular, i->toggleCheckableItem(unlistedRepliesItem)),
 				overlayMediaItem=new CheckableListItem<>(R.string.sk_settings_continues_playback, R.string.sk_settings_continues_playback_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.overlayMedia, R.drawable.ic_fluent_play_circle_hint_24_regular, i->toggleCheckableItem(overlayMediaItem)),
 				customTabsItem=new CheckableListItem<>(R.string.settings_custom_tabs, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.useCustomTabs, R.drawable.ic_fluent_link_24_regular, i->toggleCheckableItem(customTabsItem)),
 				confirmUnfollowItem=new CheckableListItem<>(R.string.settings_confirm_unfollow, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.confirmUnfollow, R.drawable.ic_fluent_person_delete_24_regular, i->toggleCheckableItem(confirmUnfollowItem)),
@@ -183,7 +182,6 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 		GlobalUserPreferences.allowRemoteLoading=remoteLoadingItem.checked;
 		GlobalUserPreferences.mentionRebloggerAutomatically=mentionRebloggerAutomaticallyItem.checked;
 		GlobalUserPreferences.hapticFeedback=hapticFeedbackItem.checked;
-		GlobalUserPreferences.defaultToUnlistedReplies=unlistedRepliesItem.checked;
 		GlobalUserPreferences.showPostsWithoutAlt=showPostsWithoutAltItem.checked;
 		GlobalUserPreferences.save();
 		AccountLocalPreferences lp=getLocalPrefs();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsPrivacyFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsPrivacyFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.StringRes;
 
+import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
@@ -23,6 +24,10 @@ public class SettingsPrivacyFragment extends BaseSettingsFragment<Void>{
 	private StatusPrivacy privacy=null;
 	private Instance instance;
 
+	//MOSHIDON
+	private CheckableListItem<Void> unlistedRepliesItem;
+
+
 	@Override
 	public void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);
@@ -32,7 +37,8 @@ public class SettingsPrivacyFragment extends BaseSettingsFragment<Void>{
 		instance=AccountSessionManager.getInstance().getInstanceInfo(session.domain);
 		privacy=self.source.privacy;
 		onDataLoaded(List.of(
-				privacyItem=new ListItem<>(R.string.sk_settings_default_visibility, getPrivacyString(privacy), R.drawable.ic_fluent_eye_24_regular, this::onPrivacyClick, 0, true),
+				privacyItem=new ListItem<>(R.string.sk_settings_default_visibility, getPrivacyString(privacy), R.drawable.ic_fluent_eye_24_regular, this::onPrivacyClick, 0, false),
+				unlistedRepliesItem=new CheckableListItem<>(R.string.mo_change_default_reply_visibility_to_unlisted, R.string.mo_setting_default_reply_privacy_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.defaultToUnlistedReplies, R.drawable.ic_fluent_lock_open_24_regular, i->toggleCheckableItem(unlistedRepliesItem), true),
 				lockedItem=new CheckableListItem<>(R.string.sk_settings_lock_account, 0, CheckableListItem.Style.SWITCH, self.locked, R.drawable.ic_fluent_person_available_24_regular, i->toggleCheckableItem(lockedItem))
 		));
 
@@ -82,6 +88,8 @@ public class SettingsPrivacyFragment extends BaseSettingsFragment<Void>{
 	@Override
 	public void onPause(){
 		super.onPause();
+		GlobalUserPreferences.defaultToUnlistedReplies=unlistedRepliesItem.checked;
+		GlobalUserPreferences.save();
 		AccountSession s=AccountSessionManager.get(accountID);
 		Account self=s.self;
 		boolean savePlease=self.locked!=lockedItem.checked


### PR DESCRIPTION
Moves the "Reply as 'Unlisted' by default" setting to the privacy settings page. It fits better on the page since it affects how visible user replies are, similar to the default posting visibility. It also makes sense to keep it on the same page since both settings have a similar effect.

![Privacy page with unlisted replies setting](https://github.com/LucasGGamerM/moshidon/assets/63370021/1cca5314-0c91-48b3-884e-dfea8372ec00)
