### PR TITLE
implement right-to-left override character removal option

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -79,6 +79,7 @@ public class GlobalUserPreferences{
 	public static boolean mentionRebloggerAutomatically;
 	public static boolean showPostsWithoutAlt;
 	public static boolean showMediaPreview;
+	public static boolean disableRightToLeftCharacter;
 
 	public static SharedPreferences getPrefs(){
 		return MastodonApp.context.getSharedPreferences("global", Context.MODE_PRIVATE);
@@ -156,6 +157,7 @@ public class GlobalUserPreferences{
 		mentionRebloggerAutomatically=prefs.getBoolean("mentionRebloggerAutomatically", false);
 		showPostsWithoutAlt=prefs.getBoolean("showPostsWithoutAlt", true);
 		showMediaPreview=prefs.getBoolean("showMediaPreview", true);
+		disableRightToLeftCharacter=prefs.getBoolean("disableRightToLeftCharacter", false);
 
 		theme=ThemePreference.values()[prefs.getInt("theme", 0)];
 
@@ -232,6 +234,7 @@ public class GlobalUserPreferences{
 				.putBoolean("enableDeleteNotifications", enableDeleteNotifications)
 				.putBoolean("showPostsWithoutAlt", showPostsWithoutAlt)
 				.putBoolean("showMediaPreview", showMediaPreview)
+				.putBoolean("disableRightToLeftCharacter", disableRightToLeftCharacter)
 
 				.apply();
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountLocalPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountLocalPreferences.java
@@ -60,6 +60,7 @@ public class AccountLocalPreferences{
 //	public Map<String, Integer> recentEmojis;
 	private final static Type notificationFiltersType = new TypeToken<PushSubscription.Alerts>() {}.getType();
 	public PushSubscription.Alerts notificationFilters;
+	public boolean disableRightToLeftCharacter;
 
 	public AccountLocalPreferences(SharedPreferences prefs, AccountSession session){
 		this.prefs=prefs;
@@ -90,6 +91,7 @@ public class AccountLocalPreferences{
 		// MOSHIDON
 //		recentEmojis=fromJson(prefs.getString("recentEmojis", "{}"), recentEmojisType, new HashMap<>());
 		notificationFilters=fromJson(prefs.getString("notificationFilters", gson.toJson(PushSubscription.Alerts.ofAll())), notificationFiltersType, PushSubscription.Alerts.ofAll());
+		disableRightToLeftCharacter=prefs.getBoolean("disableRightToLeftCharacter", false);
 	}
 
 	public long getNotificationsPauseEndTime(){
@@ -133,6 +135,7 @@ public class AccountLocalPreferences{
 				// MOSHIDON
 //				.putString("recentEmojis", gson.toJson(recentEmojis))
 				.putString("notificationFilters", gson.toJson(notificationFilters))
+				.putBoolean("disableRightToLeftCharacter", disableRightToLeftCharacter)
 				.apply();
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
@@ -34,7 +34,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 	private CheckableListItem<Void> forwardReportsItem, remoteLoadingItem, showBoostsItem, showRepliesItem, loadNewPostsItem, seeNewPostsBtnItem, overlayMediaItem;
 
 	// MOSHIDON
-    private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, hapticFeedbackItem, showPostsWithoutAltItem;
+    private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, hapticFeedbackItem, showPostsWithoutAltItem, disableRightToLeftCharacterItem;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -64,6 +64,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 				remoteLoadingItem=new CheckableListItem<>(R.string.sk_settings_allow_remote_loading, R.string.sk_settings_allow_remote_loading_explanation, CheckableListItem.Style.SWITCH, GlobalUserPreferences.allowRemoteLoading, R.drawable.ic_fluent_communication_24_regular, i->toggleCheckableItem(remoteLoadingItem)),
 				mentionRebloggerAutomaticallyItem=new CheckableListItem<>(R.string.mo_mention_reblogger_automatically, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.mentionRebloggerAutomatically, R.drawable.ic_fluent_comment_mention_24_regular, i->toggleCheckableItem(mentionRebloggerAutomaticallyItem)),
 				hapticFeedbackItem=new CheckableListItem<>(R.string.mo_haptic_feedback, R.string.mo_setting_haptic_feedback_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.hapticFeedback, R.drawable.ic_fluent_phone_vibrate_24_regular, i->toggleCheckableItem(hapticFeedbackItem), true),
+				disableRightToLeftCharacterItem=new CheckableListItem<>(R.string.mo_settings_disable_right_to_left_character, R.string.mo_setting_disable_right_to_left_character_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.disableRightToLeftCharacter, R.drawable.ic_fluent_arrow_forward_24_regular, i->toggleCheckableItem(disableRightToLeftCharacterItem)),
 				showBoostsItem=new CheckableListItem<>(R.string.sk_settings_show_boosts, 0, CheckableListItem.Style.SWITCH, lp.showBoosts, R.drawable.ic_fluent_arrow_repeat_all_24_regular, i->toggleCheckableItem(showBoostsItem)),
 				showRepliesItem=new CheckableListItem<>(R.string.sk_settings_show_replies, 0, CheckableListItem.Style.SWITCH, lp.showReplies, R.drawable.ic_fluent_arrow_reply_24_regular, i->toggleCheckableItem(showRepliesItem))
 		));
@@ -183,6 +184,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 		GlobalUserPreferences.mentionRebloggerAutomatically=mentionRebloggerAutomaticallyItem.checked;
 		GlobalUserPreferences.hapticFeedback=hapticFeedbackItem.checked;
 		GlobalUserPreferences.showPostsWithoutAlt=showPostsWithoutAltItem.checked;
+		GlobalUserPreferences.disableRightToLeftCharacter=disableRightToLeftCharacterItem.checked;
 		GlobalUserPreferences.save();
 		AccountLocalPreferences lp=getLocalPrefs();
 		boolean restartPlease=lp.showBoosts!=showBoostsItem.checked

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Account.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 
+import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.api.ObjectValidationException;
 import org.parceler.Parcel;
 
@@ -208,7 +209,14 @@ public class Account extends BaseModel implements Searchable{
 	}
 
 	public String getDisplayName(){
-		return '\u2068'+displayName+'\u2069';
+		if(GlobalUserPreferences.disableRightToLeftCharacter == true){
+
+			String buf = '\u2068'+displayName+'\u2069';
+			buf = buf.replace("\u202E", "");
+			return buf;
+		} else{
+			return '\u2068'+displayName+'\u2069';
+		}
 	}
 
 	@Override

--- a/mastodon/src/main/res/values/strings.xml
+++ b/mastodon/src/main/res/values/strings.xml
@@ -658,4 +658,6 @@
 	<string name="list_find_users">Find users to add</string>
 	<string name="sk_poll_results">View results</string>
 	<string name="sk_poll_view">Hide results</string>
+	<string name="mo_setting_disable_right_to_left_character_summary">Removes right-to-left override character from user display names. This prevents backwards text from appearing in notifications and other fields.</string>
+	<string name="mo_settings_disable_right_to_left_character">Disable right-to-left override character</string>
 </resources>


### PR DESCRIPTION
some users find the right-to-left override character annoying, this pull request adds an option under the "Behavior" subsection in settings that will strip the character in question from all account display names