### PR TITLE
feat: improve extended footer

### DIFF
--- a/mastodon/src/main/res/layout/display_item_extended_footer.xml
+++ b/mastodon/src/main/res/layout/display_item_extended_footer.xml
@@ -6,7 +6,8 @@
 	android:layout_height="wrap_content"
 	android:paddingBottom="8dp"
 	android:divider="@drawable/divider_inset_16dp"
-	android:showDividers="middle">
+	android:showDividers="middle"
+	android:background="?colorM3SurfaceVariant">
 
 	<org.joinmastodon.android.ui.views.WrappingLinearLayout
 		android:layout_width="match_parent"

--- a/mastodon/src/main/res/layout/display_item_extended_footer.xml
+++ b/mastodon/src/main/res/layout/display_item_extended_footer.xml
@@ -128,11 +128,13 @@
 			android:singleLine="true"
 			android:ellipsize="end"
 			android:paddingVertical="4dp"
-			android:paddingHorizontal="8dp"
-			android:layout_marginVertical="-4dp"
-			android:layout_marginHorizontal="-8dp"
+			android:paddingEnd="8dp"
 			android:gravity="center_vertical"
-			tools:text="123 boosts"/>
+			android:drawableStart="@drawable/ic_fluent_arrow_repeat_all_20_regular"
+			android:drawablePadding="8dp"
+			android:drawableTint="?colorM3OnSurfaceVariant"
+			tools:text="123 boosts"
+			tools:ignore="RtlSymmetry" />
 
 		<TextView
 			android:id="@+id/favorites"
@@ -146,9 +148,10 @@
 			android:ellipsize="end"
 			android:paddingVertical="4dp"
 			android:paddingHorizontal="8dp"
-			android:layout_marginVertical="-4dp"
-			android:layout_marginHorizontal="-8dp"
 			android:gravity="center_vertical"
+			android:drawableStart="@drawable/ic_fluent_star_20_regular"
+			android:drawablePadding="8dp"
+			android:drawableTint="?colorM3OnSurfaceVariant"
 			tools:text="123 favorites"/>
 
 	</org.joinmastodon.android.ui.views.WrappingLinearLayout>


### PR DESCRIPTION
Improves the extended footer, but re-adding the old background color and the icons.

| Before                                                                                                            	| After                                                                                                             	|
|-------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------	|
| ![Previous footer](https://github.com/LucasGGamerM/moshidon/assets/63370021/b56c59d0-14d7-460a-a70a-160a18a34fc5) 	| ![Improved footer](https://github.com/LucasGGamerM/moshidon/assets/63370021/44b4d605-9c2d-4695-803d-9dbaa8443edb) 	|