### PR TITLE
fix(remote-info): remove null check

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/account_list/PaginatedAccountListFragment.java
@@ -45,8 +45,7 @@ public abstract class PaginatedAccountListFragment<T> extends BaseAccountListFra
 		}
 
 		remoteDisabled = !GlobalUserPreferences.allowRemoteLoading
-				|| getSession().domain.equals(getRemoteDomain())
-				|| remoteInfoRequest == null;
+				|| getSession().domain.equals(getRemoteDomain());
 		if (!remoteDisabled) {
 			remoteInfoRequest = loadRemoteInfo().setCallback(new Callback<>() {
 				@Override


### PR DESCRIPTION
Fixes a regression introduced  in 76867a971b5ff23e05e823620ce2d3ac5ccaa4f7, that caused remote info to be permanently disabled