### PR TITLE
fix: use correct hashtag text to prevent crash

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/SignupFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/onboarding/SignupFragment.java
@@ -302,7 +302,7 @@ public class SignupFragment extends ToolbarFragment{
 						@Override
 						public void tail(Node node, int depth){
 							if(node instanceof Element){
-								ssb.setSpan(new LinkSpan("", SignupFragment.this::onGoBackLinkClick, LinkSpan.Type.CUSTOM, null, null, null), spanStart, ssb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+								ssb.setSpan(new LinkSpan("", SignupFragment.this::onGoBackLinkClick, LinkSpan.Type.CUSTOM, null, null, null, null), spanStart, ssb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 								ssb.setSpan(new TypefaceSpan("sans-serif-medium"), spanStart, ssb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 							}
 						}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/DecentralizationExplainerSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/DecentralizationExplainerSheet.java
@@ -72,7 +72,7 @@ public class DecentralizationExplainerSheet extends BottomSheet{
 			@Override
 			public void tail(Node node, int depth){
 				if(node instanceof Element){
-					ssb.setSpan(new LinkSpan("", DecentralizationExplainerSheet.this::showActivityPubAlert, LinkSpan.Type.CUSTOM, null, null, null), spanStart, ssb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+					ssb.setSpan(new LinkSpan("", DecentralizationExplainerSheet.this::showActivityPubAlert, LinkSpan.Type.CUSTOM, null, null, null, null), spanStart, ssb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 				}
 			}
 		});

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -136,8 +136,8 @@ public class HtmlParser{
 							Object linkObject=null;
 							String href=el.attr("href");
 							LinkSpan.Type linkType;
+							String text=el.text();
 							if(el.hasClass("hashtag")){
-								String text=el.text();
 								if(text.startsWith("#")){
 									linkType=LinkSpan.Type.HASHTAG;
 									href=text.substring(1);
@@ -156,7 +156,7 @@ public class HtmlParser{
 							}else{
 								linkType=LinkSpan.Type.URL;
 							}
-							openSpans.add(new SpanInfo(new LinkSpan(href, null, linkType, accountID, linkObject, parentObject), ssb.length(), el));
+							openSpans.add(new SpanInfo(new LinkSpan(href, null, linkType, accountID, linkObject, parentObject, text), ssb.length(), el));
 						}
 						case "br" -> ssb.append('\n');
 						case "span" -> {
@@ -315,7 +315,7 @@ public class HtmlParser{
 			String url=matcher.group(3);
 			if(TextUtils.isEmpty(matcher.group(4)))
 				url="http://"+url;
-			ssb.setSpan(new LinkSpan(url, null, LinkSpan.Type.URL, null, null, null), matcher.start(3), matcher.end(3), 0);
+			ssb.setSpan(new LinkSpan(url, null, LinkSpan.Type.URL, null, null, null, url), matcher.start(3), matcher.end(3), 0);
 		}while(matcher.find()); // Find more URLs
 		return ssb;
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/LinkSpan.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/LinkSpan.java
@@ -18,14 +18,16 @@ public class LinkSpan extends CharacterStyle {
 	private String accountID;
 	private Object linkObject;
 	private Object parentObject;
+	private String text;
 
-	public LinkSpan(String link, OnLinkClickListener listener, Type type, String accountID, Object linkObject, Object parentObject){
+	public LinkSpan(String link, OnLinkClickListener listener, Type type, String accountID, Object linkObject, Object parentObject, String text){
 		this.listener=listener;
 		this.link=link;
 		this.type=type;
 		this.accountID=accountID;
 		this.linkObject=linkObject;
 		this.parentObject=parentObject;
+		this.text=text;
 	}
 
 	public int getColor(){
@@ -64,7 +66,7 @@ public class LinkSpan extends CharacterStyle {
 	}
 
 	public String getText() {
-		return parentObject.toString();
+		return text;
 	}
 
 	public Type getType(){


### PR DESCRIPTION
Fixes a regression introduced in 0af8dbf09b7ca78f64842de479fdcb70ef6b86ac, taht caused the app to crash when long pressing on a hastag to copy it