### PR TITLE
feat: add instance info button to DecentralizationExplainerSheet

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -398,7 +398,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		followingBtn.setOnClickListener(this::onFollowersOrFollowingClick);
 
 		content.findViewById(R.id.username_wrap).setOnClickListener(v->{
-			UiUtils.goToInstanceAboutFragment(Uri.parse(account.url).getHost(), accountID, getContext());
+			new DecentralizationExplainerSheet(getActivity(), accountID, account).show();
 		});
 
 		content.findViewById(R.id.username_wrap).setOnLongClickListener(v->{
@@ -435,14 +435,6 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		nameEdit.addTextChangedListener(new SimpleTextWatcher(e->editDirty=true));
 		bioEdit.addTextChangedListener(new SimpleTextWatcher(e->editDirty=true));
 
-		usernameDomain.setOnClickListener(v->{
-			UiUtils.goToInstanceAboutFragment(Uri.parse(account.url).getHost(), accountID, getContext());
-		});
-
-		usernameDomain.setOnLongClickListener(v->{
-			new DecentralizationExplainerSheet(getActivity(), accountID, account).show();
-			return true;
-		});
 
 //		qrCodeButton.setOnClickListener(v->{
 //			Bundle args=new Bundle();

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/DecentralizationExplainerSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/DecentralizationExplainerSheet.java
@@ -4,6 +4,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
+import android.net.Uri;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -44,6 +45,11 @@ public class DecentralizationExplainerSheet extends BottomSheet{
 		TextView serverExplanation=findViewById(R.id.server_text);
 		TextView handleExplanation=findViewById(R.id.handle_explanation);
 		findViewById(R.id.btn_cancel).setOnClickListener(v->dismiss());
+
+		findViewById(R.id.btn_view_info).setOnClickListener(v->{
+			UiUtils.goToInstanceAboutFragment(Uri.parse(account.url).getHost(), accountID, context);
+			dismiss();
+		});
 
 		String domain=account.getDomain();
 		if(TextUtils.isEmpty(domain))

--- a/mastodon/src/main/res/layout/sheet_decentralization_info.xml
+++ b/mastodon/src/main/res/layout/sheet_decentralization_info.xml
@@ -174,5 +174,14 @@
 			style="@style/Widget.Mastodon.M3.Button.Filled"
 			android:text="@string/got_it"/>
 
+		<Button
+			android:id="@+id/btn_view_info"
+			android:layout_width="match_parent"
+			android:layout_height="40dp"
+			android:layout_marginBottom="8dp"
+			android:layout_marginHorizontal="16dp"
+			style="@style/Widget.Mastodon.M3.Button.Text"
+			android:text="@string/mo_instance_view_info"/>
+
 	</LinearLayout>
 </org.joinmastodon.android.ui.views.CustomScrollView>

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -66,6 +66,7 @@
 
     <string name="mo_share_open_url">Open in App</string>
 
+	<string name="mo_instance_view_info">View Server Info</string>
     <string name="mo_instance_admin">Administered by</string>
     <string name="mo_instance_contact">Contact</string>
     <string name="mo_instance_users">Users</string>


### PR DESCRIPTION
Adds a `View Server Info` button to the new `DecentralizationExplainerSheet`, which opens the about page of the instance. This replaces the old behavior of the DecentralizationExplainerSheet only appearing on long press, which is pretty hard to discover.

![DecentralizationExplainerSheet with a view server info button](https://github.com/LucasGGamerM/moshidon/assets/63370021/3fc87b76-3a3c-4f75-8fd0-bd95bffd2e39)
