### PR TITLE
feat: remove home tab longpress

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeFragment.java
@@ -310,11 +310,6 @@ public class HomeFragment extends AppKitFragment implements OnBackPressedListene
 			discoverFragment.openSearch();
 			return true;
 		}
-		if(tab==R.id.tab_home){
-			Bundle args=new Bundle();
-			args.putString("account", accountID);
-			Nav.go(getActivity(), OnboardingFollowSuggestionsFragment.class, args);
-		}
 		return false;
 	}
 


### PR DESCRIPTION
Removes the `OnboardingFollowSuggestionsFragment` from showing when long pressing the home tab. This feature has been removed by upstream for a while now, and is already duplicated in the discovery tab, so there is no reason to keep it.