### PR TITLE
fix: use correct openURL function

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/LinkSpan.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/LinkSpan.java
@@ -42,7 +42,7 @@ public class LinkSpan extends CharacterStyle {
 	
 	public void onClick(Context context){
 		switch(getType()){
-			case URL -> UiUtils.openURL(context, accountID, link, parentObject);
+			case URL -> UiUtils.openURL(context, accountID, link);
 			case MENTION -> UiUtils.openProfileByID(context, accountID, link);
 			case HASHTAG -> {
 				if(linkObject instanceof Hashtag ht)


### PR DESCRIPTION
Fixes an issue where the link of a `LinkSpan` would not open in the browser because the wrong method was used. This could happen for example when clicking on a link in the profile fields.

*This should not have happened in Rust :crab: comment