### PR TITLE
feat: add mute duration and notifications to mute confirmation sheet

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
@@ -4,16 +4,18 @@ import org.joinmastodon.android.api.MastodonAPIRequest;
 import org.joinmastodon.android.model.Relationship;
 
 public class SetAccountMuted extends MastodonAPIRequest<Relationship>{
-	public SetAccountMuted(String id, boolean muted, long duration){
+	public SetAccountMuted(String id, boolean muted, long duration, boolean muteNotifications){
 		super(HttpMethod.POST, "/accounts/"+id+"/"+(muted ? "mute" : "unmute"), Relationship.class);
 		if(muted)
-		setRequestBody(new Request(duration, muteNotifications));
+			setRequestBody(new Request(duration, muteNotifications));
 	}
 
 	private static class Request{
 		public long duration;
-		public Request(long duration){
+		public boolean muteNotifications;
+		public Request(long duration, boolean muteNotifications){
 			this.duration=duration;
+			this.muteNotifications=muteNotifications;
 		}
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/SetAccountMuted.java
@@ -6,7 +6,8 @@ import org.joinmastodon.android.model.Relationship;
 public class SetAccountMuted extends MastodonAPIRequest<Relationship>{
 	public SetAccountMuted(String id, boolean muted, long duration){
 		super(HttpMethod.POST, "/accounts/"+id+"/"+(muted ? "mute" : "unmute"), Relationship.class);
-		setRequestBody(new Request(duration));
+		if(muted)
+		setRequestBody(new Request(duration, muteNotifications));
 	}
 
 	private static class Request{

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountRestrictionConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountRestrictionConfirmationSheet.java
@@ -85,6 +85,9 @@ public abstract class AccountRestrictionConfirmationSheet extends BottomSheet{
 		}
 
 		AutoOrientationLinearLayout layout = new AutoOrientationLinearLayout(getContext());
+		// allow complete row to trigger child click listener
+		if(view.hasOnClickListeners())
+			layout.setOnClickListener(v -> view.performClick());
 		LinearLayout.LayoutParams lp=new LinearLayout.LayoutParams(0,ViewGroup.LayoutParams.WRAP_CONTENT);
 		lp.gravity=Gravity.CENTER;
 		lp.weight=1f;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountRestrictionConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountRestrictionConfirmationSheet.java
@@ -17,6 +17,7 @@ import org.joinmastodon.android.R;
 import org.joinmastodon.android.model.Account;
 import org.joinmastodon.android.ui.drawables.EmptyDrawable;
 import org.joinmastodon.android.ui.utils.UiUtils;
+import org.joinmastodon.android.ui.views.AutoOrientationLinearLayout;
 import org.joinmastodon.android.ui.views.ProgressBarButton;
 
 import androidx.annotation.DrawableRes;
@@ -66,7 +67,7 @@ public abstract class AccountRestrictionConfirmationSheet extends BottomSheet{
 		});
 	}
 
-	protected void addRow(@DrawableRes int icon, CharSequence text){
+	protected void addRow(@DrawableRes int icon, CharSequence text, View view) {
 		TextView tv=new TextView(getContext());
 		tv.setTextAppearance(R.style.m3_body_large);
 		tv.setTextColor(UiUtils.getThemeColor(getContext(), R.attr.colorM3OnSurfaceVariant));
@@ -77,7 +78,26 @@ public abstract class AccountRestrictionConfirmationSheet extends BottomSheet{
 		drawable.setBounds(0, 0, V.dp(40), V.dp(40));
 		tv.setCompoundDrawablesRelative(drawable, null, null, null);
 		tv.setCompoundDrawablePadding(V.dp(16));
-		contentWrap.addView(tv, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+		if(view==null){
+			contentWrap.addView(tv, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+			return;
+		}
+
+		AutoOrientationLinearLayout layout = new AutoOrientationLinearLayout(getContext());
+		LinearLayout.LayoutParams lp=new LinearLayout.LayoutParams(0,ViewGroup.LayoutParams.WRAP_CONTENT);
+		lp.weight=1f;
+		layout.addView(tv, lp);
+		layout.addView(view, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+		contentWrap.addView(layout, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+	}
+
+	protected void addRow(@DrawableRes int icon, @StringRes int text, View view){
+		addRow(icon, getContext().getString(text), view);
+	}
+
+	protected void addRow(@DrawableRes int icon, CharSequence text){
+		addRow(icon, text, null);
 	}
 
 	protected void addRow(@DrawableRes int icon, @StringRes int text){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountRestrictionConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountRestrictionConfirmationSheet.java
@@ -86,6 +86,7 @@ public abstract class AccountRestrictionConfirmationSheet extends BottomSheet{
 
 		AutoOrientationLinearLayout layout = new AutoOrientationLinearLayout(getContext());
 		LinearLayout.LayoutParams lp=new LinearLayout.LayoutParams(0,ViewGroup.LayoutParams.WRAP_CONTENT);
+		lp.gravity=Gravity.CENTER;
 		lp.weight=1f;
 		layout.addView(tv, lp);
 		layout.addView(view, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
@@ -8,14 +8,16 @@ import android.widget.PopupMenu;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.ui.views.M3Switch;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import androidx.annotation.NonNull;
 
 public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmationSheet{
-	public MuteAccountConfirmationSheet(@NonNull Context context, Account user,  AtomicReference<Duration> muteDuration, ConfirmCallback confirmCallback){
+	public MuteAccountConfirmationSheet(@NonNull Context context, Account user, AtomicReference<Duration> muteDuration, AtomicBoolean muteNotifications, ConfirmCallback confirmCallback){
 		super(context, user, confirmCallback);
 		titleView.setText(R.string.mute_user_confirm_title);
 		confirmBtn.setText(R.string.do_mute);
@@ -26,6 +28,13 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		addRow(R.drawable.ic_fluent_eye_off_24_regular, R.string.user_can_still_see_your_posts);
 		addRow(R.drawable.ic_fluent_mention_24_regular, R.string.you_wont_see_user_mentions);
 		addRow(R.drawable.ic_fluent_arrow_reply_24_regular, R.string.user_can_mention_and_follow_you);
+
+		// add mute notifications toggle (Moshidon)
+		M3Switch m3Switch=new M3Switch(getContext());
+		m3Switch.setClickable(true);
+		m3Switch.setChecked(muteNotifications.get());
+		m3Switch.setOnCheckedChangeListener((compoundButton, b) -> muteNotifications.set(b));
+		addRow(R.drawable.ic_fluent_alert_off_24_regular, R.string.mo_mute_notifications, m3Switch);
 
 		// add mute duration (Moshidon)
 		Button button=new Button(getContext());

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
@@ -34,6 +34,7 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		m3Switch.setClickable(true);
 		m3Switch.setChecked(muteNotifications.get());
 		m3Switch.setOnCheckedChangeListener((compoundButton, b) -> muteNotifications.set(b));
+		m3Switch.setOnClickListener(view -> muteNotifications.set(m3Switch.isSelected()));
 		addRow(R.drawable.ic_fluent_alert_off_24_regular, R.string.mo_mute_notifications, m3Switch);
 
 		// add mute duration (Moshidon)

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
@@ -1,17 +1,22 @@
 package org.joinmastodon.android.ui.sheets;
 
 import android.content.Context;
+import android.view.Gravity;
 import android.view.View;
+import android.widget.Button;
+import android.widget.PopupMenu;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.model.Account;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
 import androidx.annotation.NonNull;
 
 public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmationSheet{
-	public MuteAccountConfirmationSheet(@NonNull Context context, Account user, ConfirmCallback confirmCallback){
+	public MuteAccountConfirmationSheet(@NonNull Context context, Account user,  AtomicReference<Duration> muteDuration, ConfirmCallback confirmCallback){
 		super(context, user, confirmCallback);
-		//TODO: readd the time option
 		titleView.setText(R.string.mute_user_confirm_title);
 		confirmBtn.setText(R.string.do_mute);
 		secondaryBtn.setVisibility(View.GONE);
@@ -21,5 +26,43 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		addRow(R.drawable.ic_fluent_eye_off_24_regular, R.string.user_can_still_see_your_posts);
 		addRow(R.drawable.ic_fluent_mention_24_regular, R.string.you_wont_see_user_mentions);
 		addRow(R.drawable.ic_fluent_arrow_reply_24_regular, R.string.user_can_mention_and_follow_you);
+
+		// add mute duration (Moshidon)
+		Button button=new Button(getContext());
+		PopupMenu popupMenu=getMuteDurationPopupMenu(context, muteDuration, button);
+		button.setOnClickListener(v->popupMenu.show());
+		button.setOnTouchListener(popupMenu.getDragToOpenListener());
+		button.setText(popupMenu.getMenu().getItem(0).getTitle());
+
+		addRow(R.drawable.ic_fluent_clock_20_regular, R.string.sk_mute_label, button);
+	}
+
+	@NonNull
+	private PopupMenu getMuteDurationPopupMenu(@NonNull Context context, AtomicReference<Duration> muteDuration, Button button){
+		PopupMenu popupMenu=new PopupMenu(context, button, Gravity.CENTER_HORIZONTAL);
+		popupMenu.inflate(R.menu.mute_duration);
+		popupMenu.setOnMenuItemClickListener(item->{
+			int id=item.getItemId();
+			if(id==R.id.duration_indefinite)
+				muteDuration.set(Duration.ZERO);
+			else if(id==R.id.duration_minutes_5){
+				muteDuration.set(Duration.ofMinutes(5));
+			}else if(id==R.id.duration_minutes_30){
+				muteDuration.set(Duration.ofMinutes(30));
+			}else if(id==R.id.duration_hours_1){
+				muteDuration.set(Duration.ofHours(1));
+			}else if(id==R.id.duration_hours_6){
+				muteDuration.set(Duration.ofHours(6));
+			}else if(id==R.id.duration_days_1){
+				muteDuration.set(Duration.ofDays(1));
+			}else if(id==R.id.duration_days_3){
+				muteDuration.set(Duration.ofDays(3));
+			}else if(id==R.id.duration_days_7){
+				muteDuration.set(Duration.ofDays(7));
+			}
+			button.setText(item.getTitle());
+			return true;
+		});
+		return popupMenu;
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -156,6 +156,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
@@ -599,10 +600,11 @@ public class UiUtils {
 	}
 	public static void confirmToggleMuteUser(Context context, String accountID, Account account, boolean currentlyMuted, Consumer<Relationship> resultCallback){
 		if(!currentlyMuted){
-			//pass a reference to the duration, so it can be changed inside the confirmation sheet
+			//pass a references, so they can be changed inside the confirmation sheet
 			AtomicReference<Duration> muteDuration=new AtomicReference<>(Duration.ZERO);
-			new MuteAccountConfirmationSheet(context, account, muteDuration, (onSuccess, onError)->{
-				new SetAccountMuted(account.id, true, muteDuration.get().getSeconds())
+			AtomicBoolean muteNotifications=new AtomicBoolean(true);
+			new MuteAccountConfirmationSheet(context, account, muteDuration, muteNotifications, (onSuccess, onError)->{
+				new SetAccountMuted(account.id, true, muteDuration.get().getSeconds(), muteNotifications.get())
 						.setCallback(new Callback<>(){
 							@Override
 							public void onSuccess(Relationship result){
@@ -620,7 +622,7 @@ public class UiUtils {
 						.exec(accountID);
 			}).show();
 		}else{
-			new SetAccountMuted(account.id, false, 0)
+			new SetAccountMuted(account.id, false, 0, false)
 					.setCallback(new Callback<>(){
 						@Override
 						public void onSuccess(Relationship result){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -599,8 +599,10 @@ public class UiUtils {
 	}
 	public static void confirmToggleMuteUser(Context context, String accountID, Account account, boolean currentlyMuted, Consumer<Relationship> resultCallback){
 		if(!currentlyMuted){
-			new MuteAccountConfirmationSheet(context, account, (onSuccess, onError)->{
-				new SetAccountMuted(account.id, true, 0)
+			//pass a reference to the duration, so it can be changed inside the confirmation sheet
+			AtomicReference<Duration> muteDuration=new AtomicReference<>(Duration.ZERO);
+			new MuteAccountConfirmationSheet(context, account, muteDuration, (onSuccess, onError)->{
+				new SetAccountMuted(account.id, true, muteDuration.get().getSeconds())
 						.setCallback(new Callback<>(){
 							@Override
 							public void onSuccess(Relationship result){

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -119,4 +119,5 @@
 	<!--	<string name="mo_mutes">Mutes</string>-->
 	<string name="mo_blocked_accounts">Blocked accounts</string>
 <!--	<string name="mo_blocks">Blocks</string>-->
+	<string name="mo_mute_notifications">Hide notifications from this user?</string>
 </resources>


### PR DESCRIPTION
Re-adds the mute duration option to the new MuteConfirmationSheet.
Also adds the option to mute notifications from https://github.com/sk22/megalodon/pull/968.

![image](https://github.com/LucasGGamerM/moshidon/assets/63370021/8b72d2bf-7e09-400c-9480-6de957b423e7)
