### PR TITLE
fix: replace correct filter item

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -763,12 +763,14 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 	public void onGapClick(GapStatusDisplayItem.Holder item, boolean downwards){}
 
 	public void onWarningClick(WarningFilteredStatusDisplayItem.Holder warning){
-		int startPos = warning.getAbsoluteAdapterPosition();
+		WarningFilteredStatusDisplayItem filterItem=findItemOfType(warning.getItemID(), WarningFilteredStatusDisplayItem.class);
+		int startPos=displayItems.indexOf(filterItem);
 		displayItems.remove(startPos);
 		displayItems.addAll(startPos, warning.filteredItems);
 		adapter.notifyItemRangeInserted(startPos, warning.filteredItems.size() - 1);
 		if (startPos == 0) scrollToTop();
 		warning.getItem().status.filterRevealed = true;
+		list.invalidateItemDecorations();
 	}
 
 	@Override


### PR DESCRIPTION
Hopefully fixes the issue where the wrong StatusDisplayItem was removed when displaying a filtered item. This implementation is loosely based on [upstream](https://github.com/mastodon/mastodon-android/blob/36f4770cae58841b0da9364bf3d3bae853243782/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java#L434)'s.