### PR TITLE
fix(compose): disable group divider on EMUI

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -1662,7 +1662,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 			}
 		}
 		UiUtils.enablePopupMenuIcons(getActivity(), visibilityPopup);
-		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P) m.setGroupDividerEnabled(true);
+		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI()) m.setGroupDividerEnabled(true);
 		visibilityPopup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener(){
 			@Override
 			public boolean onMenuItemClick(MenuItem item){


### PR DESCRIPTION
Disables the group divider in the compose screen. See https://github.com/sk22/megalodon/pull/453 for more context.