### PR TITLE
feat(about): try to open links in-app

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
@@ -83,11 +83,7 @@ public class SettingsServerAboutFragment extends LoaderFragment{
 			public boolean shouldOverrideUrlLoading(WebView view, String url){
 				Uri uri=Uri.parse(url);
 				if(uri.getScheme().equals("http") || uri.getScheme().equals("https")){
-					if(uri.getHost()!=null && uri.getHost().equals(instance.uri))
-						//try to open linked accounts, etc in the app
-						UiUtils.openURL(getActivity(),accountID, url);
-					else
-						UiUtils.launchWebBrowser(getActivity(), url);
+					UiUtils.openURL(getActivity(),accountID, url);
 				}else{
 					Intent intent=new Intent(Intent.ACTION_VIEW, uri);
 					intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsServerAboutFragment.java
@@ -83,7 +83,11 @@ public class SettingsServerAboutFragment extends LoaderFragment{
 			public boolean shouldOverrideUrlLoading(WebView view, String url){
 				Uri uri=Uri.parse(url);
 				if(uri.getScheme().equals("http") || uri.getScheme().equals("https")){
-					UiUtils.launchWebBrowser(getActivity(), url);
+					if(uri.getHost()!=null && uri.getHost().equals(instance.uri))
+						//try to open linked accounts, etc in the app
+						UiUtils.openURL(getActivity(),accountID, url);
+					else
+						UiUtils.launchWebBrowser(getActivity(), url);
 				}else{
 					Intent intent=new Intent(Intent.ACTION_VIEW, uri);
 					intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);


### PR DESCRIPTION
The About screen often contains links the local accounts (e.g. moderators, admins) instead of always opening them in the browser, try to open them in-app first.