### PR TITLE
fix: fallback to hashtag name

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/EditTimelinesFragment.java
@@ -396,7 +396,7 @@ public class EditTimelinesFragment extends MastodonRecyclerFragment<TimelineDefi
 					tl.setTitle(name);
 					if(item == null || item.getType()==TimelineDefinition.TimelineType.HASHTAG){
 						tl.setTagOptions(
-								mainHashtag,
+								TextUtils.isEmpty(mainHashtag) ? name : mainHashtag,
 								tagsAny.getChipValues(),
 								tagsAll.getChipValues(),
 								tagsNone.getChipValues(),


### PR DESCRIPTION
Fixes an issue, where Hashtag timeline were created with an empty hashtag. This would only apply when creating a fresh timeline for a hashtag that the user does not already follow.