### PR TITLE
fix(CustomLocalTimeline): set WebUri with scheme

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/CustomLocalTimelineFragment.java
@@ -85,7 +85,10 @@ public class CustomLocalTimelineFragment extends PinnableStatusListFragment impl
 
     @Override
     public Uri getWebUri(Uri.Builder base) {
-        return Uri.parse(domain);
+		return new Uri.Builder()
+				.scheme("https")
+				.authority(domain)
+				.build();
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue, where the domain for the recents URL feature was incorrectly, without a scheme, displayed in CustomLocalTimelines.