### PR TITLE
feat: display URL in recents for more fragments

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -1,6 +1,7 @@
 package org.joinmastodon.android.fragments.discover;
 
 import android.app.Fragment;
+import android.app.assist.AssistContent;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -24,6 +25,7 @@ import org.joinmastodon.android.ui.SimpleViewHolder;
 import org.joinmastodon.android.ui.tabs.TabLayout;
 import org.joinmastodon.android.ui.tabs.TabLayoutMediator;
 import org.joinmastodon.android.ui.utils.UiUtils;
+import org.joinmastodon.android.utils.ProvidesAssistContent;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -35,7 +37,7 @@ import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.fragments.OnBackPressedListener;
 import me.grishka.appkit.utils.V;
 
-public class DiscoverFragment extends AppKitFragment implements ScrollableToTop, OnBackPressedListener, IsOnTop {
+public class DiscoverFragment extends AppKitFragment implements ScrollableToTop, OnBackPressedListener, IsOnTop, ProvidesAssistContent{
 	private static final int QUERY_RESULT=937;
 
 	private TabLayout tabLayout;
@@ -289,6 +291,13 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 			searchFragment.setQuery(currentQuery, type);
 			searchText.setText(currentQuery);
 		}
+	}
+
+	@Override
+	public void onProvideAssistContent(AssistContent assistContent) {
+		callFragmentToProvideAssistContent(searchActive
+				? searchFragment
+				: getFragmentForPage(pager.getCurrentItem()), assistContent);
 	}
 
 	private class DiscoverPagerAdapter extends RecyclerView.Adapter<SimpleViewHolder>{

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverNewsFragment.java
@@ -2,6 +2,7 @@ package org.joinmastodon.android.fragments.discover;
 
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
@@ -19,6 +20,7 @@ import org.joinmastodon.android.ui.OutlineProviders;
 import org.joinmastodon.android.ui.drawables.BlurhashCrossfadeDrawable;
 import org.joinmastodon.android.ui.utils.DiscoverInfoBannerHelper;
 import org.joinmastodon.android.ui.utils.UiUtils;
+import org.joinmastodon.android.utils.ProvidesAssistContent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +42,7 @@ import me.grishka.appkit.utils.SingleViewRecyclerAdapter;
 import me.grishka.appkit.utils.V;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class DiscoverNewsFragment extends BaseRecyclerFragment<CardViewModel> implements ScrollableToTop, IsOnTop{
+public class DiscoverNewsFragment extends BaseRecyclerFragment<CardViewModel> implements ScrollableToTop, IsOnTop, ProvidesAssistContent.ProvidesWebUri{
 	private String accountID;
 	private DiscoverInfoBannerHelper bannerHelper;
 	private MergeRecyclerAdapter mergeAdapter;
@@ -113,6 +115,16 @@ public class DiscoverNewsFragment extends BaseRecyclerFragment<CardViewModel> im
 	@Override
 	public boolean isOnTop(){
 		return isRecyclerViewOnTop(list);
+	}
+
+	@Override
+	public String getAccountID() {
+		return accountID;
+	}
+
+	@Override
+	public Uri getWebUri(Uri.Builder base) {
+		return isInstanceAkkoma() ? null : base.path("/explore/links").build();
 	}
 
 	private class LinksAdapter extends UsableRecyclerView.Adapter<BaseLinkViewHolder> implements ImageLoaderRecyclerAdapter{

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/TrendingHashtagsFragment.java
@@ -1,5 +1,6 @@
 package org.joinmastodon.android.fragments.discover;
 
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
@@ -13,6 +14,7 @@ import org.joinmastodon.android.fragments.ScrollableToTop;
 import org.joinmastodon.android.model.Hashtag;
 import org.joinmastodon.android.ui.utils.UiUtils;
 import org.joinmastodon.android.ui.views.HashtagChartView;
+import org.joinmastodon.android.utils.ProvidesAssistContent;
 
 import java.util.List;
 
@@ -23,7 +25,7 @@ import me.grishka.appkit.fragments.BaseRecyclerFragment;
 import me.grishka.appkit.utils.BindableViewHolder;
 import me.grishka.appkit.views.UsableRecyclerView;
 
-public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop{
+public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> implements ScrollableToTop, IsOnTop, ProvidesAssistContent.ProvidesWebUri{
 	private String accountID;
 
 	public TrendingHashtagsFragment(){
@@ -63,6 +65,16 @@ public class TrendingHashtagsFragment extends BaseRecyclerFragment<Hashtag> impl
 	@Override
 	public boolean isOnTop(){
 		return isRecyclerViewOnTop(list);
+	}
+
+	@Override
+	public String getAccountID() {
+		return accountID;
+	}
+
+	@Override
+	public Uri getWebUri(Uri.Builder base) {
+		return isInstanceAkkoma() ? null : base.path("/explore/tags").build();
 	}
 
 	private class HashtagsAdapter extends RecyclerView.Adapter<HashtagViewHolder>{

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/BaseSettingsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/BaseSettingsFragment.java
@@ -1,11 +1,13 @@
 package org.joinmastodon.android.fragments.settings;
 
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.WindowInsets;
 
 import org.joinmastodon.android.R;
+import org.joinmastodon.android.fragments.HasAccountID;
 import org.joinmastodon.android.fragments.MastodonRecyclerFragment;
 import org.joinmastodon.android.model.viewmodel.CheckableListItem;
 import org.joinmastodon.android.model.viewmodel.ListItem;
@@ -14,10 +16,11 @@ import org.joinmastodon.android.ui.DividerItemDecoration;
 import org.joinmastodon.android.ui.adapters.GenericListItemsAdapter;
 import org.joinmastodon.android.ui.viewholders.ListItemViewHolder;
 import org.joinmastodon.android.ui.viewholders.SimpleListItemViewHolder;
+import org.joinmastodon.android.utils.ProvidesAssistContent;
 
 import androidx.recyclerview.widget.RecyclerView;
 
-public abstract class BaseSettingsFragment<T> extends MastodonRecyclerFragment<ListItem<T>>{
+public abstract class BaseSettingsFragment<T> extends MastodonRecyclerFragment<ListItem<T>> implements HasAccountID, ProvidesAssistContent.ProvidesWebUri{
 	protected GenericListItemsAdapter<T> itemsAdapter;
 	protected String accountID;
 
@@ -82,5 +85,15 @@ public abstract class BaseSettingsFragment<T> extends MastodonRecyclerFragment<L
 			list.setPadding(0, 0, 0, 0);
 		}
 		super.onApplyWindowInsets(insets);
+	}
+
+	@Override
+	public String getAccountID() {
+		return accountID;
+	}
+
+	@Override
+	public Uri getWebUri(Uri.Builder base) {
+		return base.path("/settings").build();
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/EditFilterFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/EditFilterFragment.java
@@ -1,6 +1,7 @@
 package org.joinmastodon.android.fragments.settings;
 
 import android.app.AlertDialog;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.view.Menu;
@@ -328,5 +329,9 @@ public class EditFilterFragment extends BaseSettingsFragment<Void> implements On
 			return true;
 		}
 		return false;
+	}
+	@Override
+	public Uri getWebUri(Uri.Builder base) {
+		return base.path(filter == null ? "/filters/new" : "/filters/"+ filter.id + "/edit").build();
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsFiltersFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsFiltersFragment.java
@@ -1,5 +1,6 @@
 package org.joinmastodon.android.fragments.settings;
 
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.squareup.otto.Subscribe;
@@ -106,5 +107,10 @@ public class SettingsFiltersFragment extends BaseSettingsFragment<Filter>{
 		}
 		data.add(makeListItem(ev.filter));
 		itemsAdapter.notifyItemInserted(data.size()-1);
+	}
+
+	@Override
+	public Uri getWebUri(Uri.Builder base) {
+		return base.path("/filters").build();
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
@@ -363,4 +363,9 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 					rebindItem(unifiedPushItem);
 				}).setOnCancelListener(d->rebindItem(unifiedPushItem)).show();
 	}
+
+	@Override
+	public Uri getWebUri(Uri.Builder base) {
+		return base.path("/settings/preferences/notifications").build();
+	}
 }


### PR DESCRIPTION
Prompted by https://github.com/LucasGGamerM/moshidon/pull/404, I've noticed a few more fragments that lost their implementation. I also re-implemented the URL for settings, since the upstream implementation did not have it. When possible, the equivalent web URL is displayed, otherwise just the generic `/settings` one.