### PR TITLE
feat(Poll): scale animation based on votes

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/PollOptionStatusDisplayItem.java
@@ -150,10 +150,11 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 			item.showResults = shown;
 			item.calculateResults();
 			Drawable bg=progressBg;
+			long animationDuration = (long) (ANIMATION_DURATION*item.votesFraction);
 			int startLevel=shown ? 0 : progressBg.getLevel();
 			int targetLevel=shown ? Math.round(10000f*item.votesFraction) : 0;
 			ObjectAnimator animator=ObjectAnimator.ofInt(bg, "level", startLevel, targetLevel);
-			animator.setDuration(ANIMATION_DURATION);
+			animator.setDuration(animationDuration);
 			animator.setInterpolator(new DecelerateInterpolator());
 			button.setBackground(bg);
 			if(shown){
@@ -161,7 +162,7 @@ public class PollOptionStatusDisplayItem extends StatusDisplayItem{
 				// animate percent
 				percent.setVisibility(View.VISIBLE);
 				ValueAnimator percentAnimation=ValueAnimator.ofInt(0, Math.round(100f*item.votesFraction));
-				percentAnimation.setDuration(ANIMATION_DURATION);
+				percentAnimation.setDuration(animationDuration);
 				percentAnimation.setInterpolator(new DecelerateInterpolator());
 				percentAnimation.addUpdateListener(animation -> percent.setText(String.format(Locale.getDefault(), "%d%%", (int) animation.getAnimatedValue())));
 				percentAnimation.start();


### PR DESCRIPTION
Updates the animation timing, to be based on the amount of votes a option received relative to the other options. This means a option with more votes will run longer than one with less votes. Overall this makes the animation appear more dynamic and smoother.

Animation with equal duration:

[Poll animation with equal duration](https://github.com/LucasGGamerM/moshidon/assets/63370021/d19f6966-c541-4857-8961-50b79f684e21)

Animation with dynamic duration:

[Poll animation with dynamic duration](https://github.com/LucasGGamerM/moshidon/assets/63370021/cf1ed086-6531-42d1-a040-833f1ffcc5f9)