### PR TITLE
feat: warn if UP is disabled on FDroid variant

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
@@ -1,7 +1,5 @@
 package org.joinmastodon.android.fragments.settings;
 
-import static org.unifiedpush.android.connector.UnifiedPush.getDistributor;
-
 import android.app.AlertDialog;
 import android.app.NotificationManager;
 import android.content.Intent;
@@ -15,6 +13,7 @@ import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import org.joinmastodon.android.BuildConfig;
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.PushSubscriptionManager;
@@ -48,6 +47,7 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 	private HideableSingleViewRecyclerAdapter bannerAdapter;
 	private ImageView bannerIcon;
 	private TextView bannerText;
+	private TextView bannerTitle;
 	private Button bannerButton;
 
 	private CheckableListItem<Void> mentionsItem, boostsItem, favoritesItem, followersItem, pollsItem;
@@ -72,7 +72,7 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 		lp=AccountSessionManager.get(accountID).getLocalPreferences();
 
 		getPushSubscription();
-		useUnifiedPush=!getDistributor(getContext()).isEmpty();
+		useUnifiedPush=!UnifiedPush.getDistributor(getContext()).isEmpty();
 
 		onDataLoaded(List.of(
 				pauseItem=new CheckableListItem<>(getString(R.string.pause_all_notifications), getPauseItemSubtitle(), CheckableListItem.Style.SWITCH, false, R.drawable.ic_fluent_alert_snooze_24_regular, i->onPauseNotificationsClick(false)),
@@ -158,6 +158,7 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 	@Override
 	protected RecyclerView.Adapter<?> getAdapter(){
 		View banner=getActivity().getLayoutInflater().inflate(R.layout.item_settings_banner, list, false);
+		bannerTitle=banner.findViewById(R.id.title);
 		bannerText=banner.findViewById(R.id.text);
 		bannerIcon=banner.findViewById(R.id.icon);
 		bannerButton=banner.findViewById(R.id.button);
@@ -315,6 +316,20 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 			bannerText.setText(R.string.notifications_disabled_in_system);
 			bannerButton.setText(R.string.open_system_notification_settings);
 			bannerButton.setOnClickListener(v->openSystemNotificationSettings());
+		}else if(BuildConfig.BUILD_TYPE.equals("fdroidRelease") && UnifiedPush.getDistributor(getContext()).isEmpty()){
+			bannerAdapter.setVisible(true);
+			bannerIcon.setImageResource(R.drawable.ic_fluent_warning_24_filled);
+			bannerTitle.setVisibility(View.VISIBLE);
+			bannerTitle.setText(R.string.mo_settings_unifiedpush_warning);
+			if(UnifiedPush.getDistributors(getContext(), new ArrayList<>()).isEmpty()) {
+				bannerText.setText(R.string.mo_settings_unifiedpush_warning_no_distributors);
+				bannerButton.setText(R.string.info);
+				bannerButton.setOnClickListener(v->UiUtils.launchWebBrowser(getContext(), "https://unifiedpush.org/"));
+			} else {
+				bannerText.setText(R.string.mo_settings_unifiedpush_warning_disabled);
+				bannerButton.setText(R.string.mo_settings_unifiedpush_enable);
+				bannerButton.setOnClickListener(v->onUnifiedPushClick());
+			}
 		}else if(pauseTime>System.currentTimeMillis()){
 			bannerAdapter.setVisible(true);
 			bannerIcon.setImageResource(R.drawable.ic_fluent_alert_snooze_24_regular);
@@ -327,7 +342,7 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 	}
 
 	private void onUnifiedPushClick(){
-		if(getDistributor(getContext()).isEmpty()){
+		if(UnifiedPush.getDistributor(getContext()).isEmpty()){
 			List<String> distributors = UnifiedPush.getDistributors(getContext(), new ArrayList<>());
 			showUnifiedPushRegisterDialog(distributors);
 			return;

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -113,6 +113,10 @@
 	<string name="mo_recent_emoji_cleared">Recent emoji cleared</string>
 	<string name="mo_show_media_preview">Show media preview in timelines</string>
 	<string name="mo_notification_filter_reset">Reset to default</string>
+	<string name="mo_settings_unifiedpush_warning">UnifiedPush not enabled</string>
+	<string name="mo_settings_unifiedpush_warning_no_distributors">No UnifiedPush Distributors installed. You will not receive any notifications.</string>
+	<string name="mo_settings_unifiedpush_warning_disabled">UnifiedPush is not enabled. You will not receive any notifications.</string>
+	<string name="mo_settings_unifiedpush_enable">Enable</string>
 
 	<!--	Temporary Strings. They exist in strings_sk.xml, but are not available on Megalodon's weblate-->
 	<string name="mo_muted_accounts">Muted accounts</string>


### PR DESCRIPTION
Displays a warning in the notifications settings fragment, if UnifiedPush is disabled (or cannot be enabled). The warning will be only displayed on the FDroid build variant, since other versions use FCM by default.

![A warning stating that UP is not enabled](https://github.com/LucasGGamerM/moshidon/assets/63370021/4dcdd1dc-753c-4481-9f3a-0ff7f5abf0ad)
![A warning stating that no UP distributors are installed](https://github.com/LucasGGamerM/moshidon/assets/63370021/a2eb1a69-181d-4e1f-9fd3-fe536ac723f2)

Should help a bit to avoid issues such as https://github.com/LucasGGamerM/moshidon/issues/341 and https://github.com/LucasGGamerM/moshidon/issues/337
