### PR TITLE
refactor: share img/show preview

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/photoviewer/PhotoViewer.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/photoviewer/PhotoViewer.java
@@ -648,7 +648,8 @@ public class PhotoViewer implements ZoomPanView.Listener{
 	private void shareFile(@NonNull File file) {
 		Intent intent = new Intent(Intent.ACTION_SEND);
 		Uri outputUri = FileProvider.getUriForFile(activity, activity.getPackageName() + ".fileprovider", file);
-		intent.setType(mimeTypeForFileName(outputUri.getLastPathSegment()));
+		intent.setDataAndType(outputUri, mimeTypeForFileName(outputUri.getLastPathSegment()));
+		intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 		intent.putExtra(Intent.EXTRA_STREAM, outputUri);
 		activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.button_share)));
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/photoviewer/PhotoViewer.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/photoviewer/PhotoViewer.java
@@ -482,40 +482,29 @@ public class PhotoViewer implements ZoomPanView.Listener{
 
 	private void shareCurrentFile(){
 		Attachment att=attachments.get(pager.getCurrentItem());
-		Intent intent = new Intent(Intent.ACTION_SEND);
 
-		if(att.type==Attachment.Type.IMAGE){
-			UrlImageLoaderRequest req=new UrlImageLoaderRequest(att.url);
-			try{
-				File file=ImageCache.getInstance(activity).getFile(req);
-				if(file==null){
-					shareAfterDownloading(att);
-					return;
-				}
-				MastodonAPIController.runInBackground(()->{
-					File imageDir = new File(activity.getCacheDir(), ".");
-					File renamedFile;
-					file.renameTo(renamedFile = new File(imageDir, Uri.parse(att.url).getLastPathSegment()));
-					Uri outputUri = FileProvider.getUriForFile(activity, activity.getPackageName() + ".fileprovider", renamedFile);
-
-					// setting type to image
-					intent.setType(mimeTypeForFileName(outputUri.getLastPathSegment()));
-
-					intent.putExtra(Intent.EXTRA_STREAM, outputUri);
-
-					// calling startactivity() to share
-					activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.button_share)));
-
-				});
-			}catch(IOException x){
-				Log.w(TAG, "shareCurrentFile: ", x);
-				Toast.makeText(activity, R.string.error, Toast.LENGTH_SHORT).show();
-			}
-		}else{
+		if(att.type!=Attachment.Type.IMAGE){
 			shareAfterDownloading(att);
+			return;
 		}
 
-
+		UrlImageLoaderRequest req=new UrlImageLoaderRequest(att.url);
+		try{
+			File file=ImageCache.getInstance(activity).getFile(req);
+			if(file==null){
+				shareAfterDownloading(att);
+				return;
+			}
+			MastodonAPIController.runInBackground(()->{
+				File imageDir=new File(activity.getCacheDir(), ".");
+				File renamedFile;
+				file.renameTo(renamedFile=new File(imageDir, Uri.parse(att.url).getLastPathSegment()));
+				shareFile(renamedFile);
+			});
+		}catch(IOException x){
+			Log.w(TAG, "shareCurrentFile: ", x);
+			Toast.makeText(activity, R.string.error, Toast.LENGTH_SHORT).show();
+		}
 	}
 
 	private void saveCurrentFile(){
@@ -649,18 +638,19 @@ public class PhotoViewer implements ZoomPanView.Listener{
 
 				outputStream.close();
 				inputStream.close();
-
-				Intent intent = new Intent(Intent.ACTION_SEND);
-
-				Uri outputUri = FileProvider.getUriForFile(activity, activity.getPackageName() + ".fileprovider", file);
-
-				intent.setType(mimeTypeForFileName(outputUri.getLastPathSegment()));
-				intent.putExtra(Intent.EXTRA_STREAM, outputUri);
-				activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.button_share)));
+				shareFile(file);
 			} catch(IOException e){
 				Toast.makeText(activity, R.string.error, Toast.LENGTH_SHORT).show();
 			}
 		});
+	}
+
+	private void shareFile(@NonNull File file) {
+		Intent intent = new Intent(Intent.ACTION_SEND);
+		Uri outputUri = FileProvider.getUriForFile(activity, activity.getPackageName() + ".fileprovider", file);
+		intent.setType(mimeTypeForFileName(outputUri.getLastPathSegment()));
+		intent.putExtra(Intent.EXTRA_STREAM, outputUri);
+		activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.button_share)));
 	}
 
 	private void onAudioFocusChanged(int change){


### PR DESCRIPTION
Cleanup the code for sharing an image a bit, as well as showing a preview for the shared images, for devices running higher than API 29.

![Sharesheet with image preview](https://github.com/LucasGGamerM/moshidon/assets/63370021/2bcde059-e0da-46fb-a7ff-8e886a6c8583)
