### PR TITLE
fix: make autoexpand content warning option also expand cws that start with "re:"

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ThreadFragment.java
@@ -230,10 +230,13 @@ public class ThreadFragment extends StatusListFragment implements ProvidesAssist
 				s.filterRevealed = oldStatus.filterRevealed;
 			}
 			if (GlobalUserPreferences.autoRevealEqualSpoilers != AutoRevealMode.NEVER &&
-					s.spoilerText != null &&
-					s.spoilerText.equals(mainStatus.spoilerText)) {
-				if (GlobalUserPreferences.autoRevealEqualSpoilers == AutoRevealMode.DISCUSSIONS || Objects.equals(mainStatus.account.id, s.account.id)) {
-					s.spoilerRevealed = mainStatus.spoilerRevealed;
+					s.spoilerText != null){
+				if (s.spoilerText.equals(mainStatus.spoilerText) ||
+						(s.spoilerText.toLowerCase().startsWith("re: ") &&
+								s.spoilerText.substring(4).equals(mainStatus.spoilerText))){
+					if (GlobalUserPreferences.autoRevealEqualSpoilers == AutoRevealMode.DISCUSSIONS || Objects.equals(mainStatus.account.id, s.account.id)) {
+						s.spoilerRevealed = mainStatus.spoilerRevealed;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
this will also expand content warnings that start with any variation like capitalized "RE:"