### PR TITLE
feat: cleanup settings

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -77,7 +77,6 @@ public class GlobalUserPreferences{
 	public static boolean confirmBeforeReblog;
 	public static boolean replyLineAboveHeader;
 	public static boolean swapBookmarkWithBoostAction;
-	public static boolean loadRemoteAccountFollowers;
 	public static boolean mentionRebloggerAutomatically;
 	public static boolean showPostsWithoutAlt;
 	public static boolean showMediaPreview;
@@ -158,7 +157,6 @@ public class GlobalUserPreferences{
 		replyLineAboveHeader=prefs.getBoolean("replyLineAboveHeader", true);
 		confirmBeforeReblog=prefs.getBoolean("confirmBeforeReblog", false);
 		swapBookmarkWithBoostAction=prefs.getBoolean("swapBookmarkWithBoostAction", false);
-		loadRemoteAccountFollowers=prefs.getBoolean("loadRemoteAccountFollowers", true);
 		mentionRebloggerAutomatically=prefs.getBoolean("mentionRebloggerAutomatically", false);
 		showPostsWithoutAlt=prefs.getBoolean("showPostsWithoutAlt", true);
 		showMediaPreview=prefs.getBoolean("showMediaPreview", true);
@@ -230,7 +228,6 @@ public class GlobalUserPreferences{
 				.putBoolean("replyLineAboveHeader", replyLineAboveHeader)
 				.putBoolean("confirmBeforeReblog", confirmBeforeReblog)
 				.putBoolean("swapBookmarkWithBoostAction", swapBookmarkWithBoostAction)
-				.putBoolean("loadRemoteAccountFollowers", loadRemoteAccountFollowers)
 				.putBoolean("mentionRebloggerAutomatically", mentionRebloggerAutomatically)
 				.putBoolean("showDividers", showDividers)
 				.putBoolean("relocatePublishButton", relocatePublishButton)

--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -57,7 +57,6 @@ public class GlobalUserPreferences{
 	public static boolean spectatorMode;
 	public static boolean autoHideFab;
 	public static boolean allowRemoteLoading;
-	public static boolean forwardReportDefault;
 	public static AutoRevealMode autoRevealEqualSpoilers;
 	public static boolean disableM3PillActiveIndicator;
 	public static boolean showNavigationLabels;
@@ -135,7 +134,6 @@ public class GlobalUserPreferences{
 		autoHideFab=prefs.getBoolean("autoHideFab", true);
 		allowRemoteLoading=prefs.getBoolean("allowRemoteLoading", true);
 		autoRevealEqualSpoilers=AutoRevealMode.valueOf(prefs.getString("autoRevealEqualSpoilers", AutoRevealMode.THREADS.name()));
-		forwardReportDefault=prefs.getBoolean("forwardReportDefault", true);
 		disableM3PillActiveIndicator=prefs.getBoolean("disableM3PillActiveIndicator", false);
 		showNavigationLabels=prefs.getBoolean("showNavigationLabels", true);
 		displayPronounsInTimelines=prefs.getBoolean("displayPronounsInTimelines", true);
@@ -209,7 +207,6 @@ public class GlobalUserPreferences{
 				.putBoolean("autoHideFab", autoHideFab)
 				.putBoolean("allowRemoteLoading", allowRemoteLoading)
 				.putString("autoRevealEqualSpoilers", autoRevealEqualSpoilers.name())
-				.putBoolean("forwardReportDefault", forwardReportDefault)
 				.putBoolean("disableM3PillActiveIndicator", disableM3PillActiveIndicator)
 				.putBoolean("showNavigationLabels", showNavigationLabels)
 				.putBoolean("displayPronounsInTimelines", displayPronounsInTimelines)

--- a/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/GlobalUserPreferences.java
@@ -75,7 +75,6 @@ public class GlobalUserPreferences{
 	public static boolean doubleTapToSearch;
 	public static boolean doubleTapToSwipe;
 	public static boolean confirmBeforeReblog;
-	public static boolean hapticFeedback;
 	public static boolean replyLineAboveHeader;
 	public static boolean swapBookmarkWithBoostAction;
 	public static boolean loadRemoteAccountFollowers;
@@ -158,7 +157,6 @@ public class GlobalUserPreferences{
 		doubleTapToSwipe =prefs.getBoolean("doubleTapToSwipe", true);
 		replyLineAboveHeader=prefs.getBoolean("replyLineAboveHeader", true);
 		confirmBeforeReblog=prefs.getBoolean("confirmBeforeReblog", false);
-		hapticFeedback=prefs.getBoolean("hapticFeedback", true);
 		swapBookmarkWithBoostAction=prefs.getBoolean("swapBookmarkWithBoostAction", false);
 		loadRemoteAccountFollowers=prefs.getBoolean("loadRemoteAccountFollowers", true);
 		mentionRebloggerAutomatically=prefs.getBoolean("mentionRebloggerAutomatically", false);
@@ -233,7 +231,6 @@ public class GlobalUserPreferences{
 				.putBoolean("confirmBeforeReblog", confirmBeforeReblog)
 				.putBoolean("swapBookmarkWithBoostAction", swapBookmarkWithBoostAction)
 				.putBoolean("loadRemoteAccountFollowers", loadRemoteAccountFollowers)
-				.putBoolean("hapticFeedback", hapticFeedback)
 				.putBoolean("mentionRebloggerAutomatically", mentionRebloggerAutomatically)
 				.putBoolean("showDividers", showDividers)
 				.putBoolean("relocatePublishButton", relocatePublishButton)

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/report/ReportCommentFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/report/ReportCommentFragment.java
@@ -100,7 +100,6 @@ public class ReportCommentFragment extends MastodonToolbarFragment{
 
 		ProgressBar topProgress=view.findViewById(R.id.top_progress);
 		topProgress.setProgress(getArguments().containsKey("ruleIDs") ? 75 : 66);
-		forwardSwitch.setChecked(GlobalUserPreferences.forwardReportDefault);
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
@@ -1,18 +1,10 @@
 package org.joinmastodon.android.fragments.settings;
 
-import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 
 import org.joinmastodon.android.GlobalUserPreferences;
 import org.joinmastodon.android.R;
@@ -30,7 +22,10 @@ import org.joinmastodon.android.utils.MastodonLanguage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 
 public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> implements HasAccountID{
 	private ListItem<Void> languageItem;
@@ -44,7 +39,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 	private CheckableListItem<Void> forwardReportsItem, remoteLoadingItem, showBoostsItem, showRepliesItem, loadNewPostsItem, seeNewPostsBtnItem, overlayMediaItem;
 
 	// MOSHIDON
-    private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, hapticFeedbackItem, showPostsWithoutAltItem;
+    private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, showPostsWithoutAltItem;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState){
@@ -72,8 +67,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 				loadNewPostsItem=new CheckableListItem<>(R.string.sk_settings_load_new_posts, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.loadNewPosts, R.drawable.ic_fluent_arrow_sync_24_regular, i->onLoadNewPostsClick()),
 				seeNewPostsBtnItem=new CheckableListItem<>(R.string.sk_settings_see_new_posts_button, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.showNewPostsButton, R.drawable.ic_fluent_arrow_up_24_regular, i->toggleCheckableItem(seeNewPostsBtnItem)),
 				remoteLoadingItem=new CheckableListItem<>(R.string.sk_settings_allow_remote_loading, R.string.sk_settings_allow_remote_loading_explanation, CheckableListItem.Style.SWITCH, GlobalUserPreferences.allowRemoteLoading, R.drawable.ic_fluent_communication_24_regular, i->toggleCheckableItem(remoteLoadingItem)),
-				mentionRebloggerAutomaticallyItem=new CheckableListItem<>(R.string.mo_mention_reblogger_automatically, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.mentionRebloggerAutomatically, R.drawable.ic_fluent_comment_mention_24_regular, i->toggleCheckableItem(mentionRebloggerAutomaticallyItem)),
-				hapticFeedbackItem=new CheckableListItem<>(R.string.mo_haptic_feedback, R.string.mo_setting_haptic_feedback_summary, CheckableListItem.Style.SWITCH, GlobalUserPreferences.hapticFeedback, R.drawable.ic_fluent_phone_vibrate_24_regular, i->toggleCheckableItem(hapticFeedbackItem), true),
+				mentionRebloggerAutomaticallyItem=new CheckableListItem<>(R.string.mo_mention_reblogger_automatically, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.mentionRebloggerAutomatically, R.drawable.ic_fluent_comment_mention_24_regular, i->toggleCheckableItem(mentionRebloggerAutomaticallyItem), true),
 				showBoostsItem=new CheckableListItem<>(R.string.sk_settings_show_boosts, 0, CheckableListItem.Style.SWITCH, lp.showBoosts, R.drawable.ic_fluent_arrow_repeat_all_24_regular, i->toggleCheckableItem(showBoostsItem)),
 				showRepliesItem=new CheckableListItem<>(R.string.sk_settings_show_replies, 0, CheckableListItem.Style.SWITCH, lp.showReplies, R.drawable.ic_fluent_arrow_reply_24_regular, i->toggleCheckableItem(showRepliesItem))
 		));
@@ -219,7 +213,6 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 		GlobalUserPreferences.showNewPostsButton=seeNewPostsBtnItem.checked;
 		GlobalUserPreferences.allowRemoteLoading=remoteLoadingItem.checked;
 		GlobalUserPreferences.mentionRebloggerAutomatically=mentionRebloggerAutomaticallyItem.checked;
-		GlobalUserPreferences.hapticFeedback=hapticFeedbackItem.checked;
 		GlobalUserPreferences.showPostsWithoutAlt=showPostsWithoutAltItem.checked;
 		GlobalUserPreferences.save();
 		AccountLocalPreferences lp=getLocalPrefs();

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsBehaviorFragment.java
@@ -36,7 +36,7 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 	// MEGALODON
 	private MastodonLanguage.LanguageResolver languageResolver;
 	private ListItem<Void> prefixRepliesItem, replyVisibilityItem, customTabsItem;
-	private CheckableListItem<Void> forwardReportsItem, remoteLoadingItem, showBoostsItem, showRepliesItem, loadNewPostsItem, seeNewPostsBtnItem, overlayMediaItem;
+	private CheckableListItem<Void> remoteLoadingItem, showBoostsItem, showRepliesItem, loadNewPostsItem, seeNewPostsBtnItem, overlayMediaItem;
 
 	// MOSHIDON
     private CheckableListItem<Void> mentionRebloggerAutomaticallyItem, showPostsWithoutAltItem;
@@ -63,7 +63,6 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 				confirmBoostItem=new CheckableListItem<>(R.string.settings_confirm_boost, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.confirmBoost, R.drawable.ic_fluent_arrow_repeat_all_24_regular, i->toggleCheckableItem(confirmBoostItem)),
 				confirmDeleteItem=new CheckableListItem<>(R.string.settings_confirm_delete_post, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.confirmDeletePost, R.drawable.ic_fluent_delete_24_regular, i->toggleCheckableItem(confirmDeleteItem)),
 				prefixRepliesItem=new ListItem<>(R.string.sk_settings_prefix_reply_cw_with_re, getPrefixWithRepliesString(), R.drawable.ic_fluent_arrow_reply_24_regular, this::onPrefixRepliesClick),
-				forwardReportsItem=new CheckableListItem<>(R.string.sk_settings_forward_report_default, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.forwardReportDefault, R.drawable.ic_fluent_arrow_forward_24_regular, i->toggleCheckableItem(forwardReportsItem)),
 				loadNewPostsItem=new CheckableListItem<>(R.string.sk_settings_load_new_posts, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.loadNewPosts, R.drawable.ic_fluent_arrow_sync_24_regular, i->onLoadNewPostsClick()),
 				seeNewPostsBtnItem=new CheckableListItem<>(R.string.sk_settings_see_new_posts_button, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.showNewPostsButton, R.drawable.ic_fluent_arrow_up_24_regular, i->toggleCheckableItem(seeNewPostsBtnItem)),
 				remoteLoadingItem=new CheckableListItem<>(R.string.sk_settings_allow_remote_loading, R.string.sk_settings_allow_remote_loading_explanation, CheckableListItem.Style.SWITCH, GlobalUserPreferences.allowRemoteLoading, R.drawable.ic_fluent_communication_24_regular, i->toggleCheckableItem(remoteLoadingItem)),
@@ -208,7 +207,6 @@ public class SettingsBehaviorFragment extends BaseSettingsFragment<Void> impleme
 		GlobalUserPreferences.confirmUnfollow=confirmUnfollowItem.checked;
 		GlobalUserPreferences.confirmBoost=confirmBoostItem.checked;
 		GlobalUserPreferences.confirmDeletePost=confirmDeleteItem.checked;
-		GlobalUserPreferences.forwardReportDefault=forwardReportsItem.checked;
 		GlobalUserPreferences.loadNewPosts=loadNewPostsItem.checked;
 		GlobalUserPreferences.showNewPostsButton=seeNewPostsBtnItem.checked;
 		GlobalUserPreferences.allowRemoteLoading=remoteLoadingItem.checked;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/FooterStatusDisplayItem.java
@@ -475,24 +475,23 @@ public class FooterStatusDisplayItem extends StatusDisplayItem{
 		}
 
 		private static void vibrateForAction(View view, boolean isPositive) {
-			if (!GlobalUserPreferences.hapticFeedback) return;
-
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 				view.performHapticFeedback(isPositive ? HapticFeedbackConstants.CONFIRM : HapticFeedbackConstants.REJECT);
-			} else {
-				Vibrator vibrator = view.getContext().getSystemService(Vibrator.class);
+				return;
+			}
 
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-					vibrator.vibrate(VibrationEffect.createPredefined(isPositive ? VibrationEffect.EFFECT_CLICK : VibrationEffect.EFFECT_DOUBLE_CLICK));
-				} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-					VibrationEffect effect = isPositive
-							? VibrationEffect.createOneShot(75L, 128)
-							: VibrationEffect.createWaveform(new long[]{0L, 75L, 75L, 75L}, new int[]{0, 128, 0, 128}, -1);
-					vibrator.vibrate(effect);
-				} else {
-					if (isPositive) vibrator.vibrate(75L);
-					else vibrator.vibrate(new long[]{0L, 75L, 75L, 75L}, -1);
-				}
+			Vibrator vibrator = view.getContext().getSystemService(Vibrator.class);
+
+			if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+				vibrator.vibrate(VibrationEffect.createPredefined(isPositive ? VibrationEffect.EFFECT_CLICK : VibrationEffect.EFFECT_DOUBLE_CLICK));
+			} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+				VibrationEffect effect = isPositive
+						? VibrationEffect.createOneShot(75L, 128)
+						: VibrationEffect.createWaveform(new long[]{0L, 75L, 75L, 75L}, new int[]{0, 128, 0, 128}, -1);
+				vibrator.vibrate(effect);
+			} else {
+				if (isPositive) vibrator.vibrate(75L);
+				else vibrator.vibrate(new long[]{0L, 75L, 75L, 75L}, -1);
 			}
 		}
 	}


### PR DESCRIPTION
Cleans up the settings by removing some of the more unnecessary settings:

- `hapticFeedback`: This can already be controlled from the Android settings
- `loadRemoteAccountFollowers`: this setting isn't used anywhere
- `forwardReportDefault`: I don't think there is any good reason to change the default value of the switch