### PR TITLE
fix: disable GroupDivider on Honor's MagicOS

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -1663,7 +1663,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 			}
 		}
 		UiUtils.enablePopupMenuIcons(getActivity(), visibilityPopup);
-		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI()) m.setGroupDividerEnabled(true);
+		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI() && !UiUtils.isMagic()) m.setGroupDividerEnabled(true);
 		visibilityPopup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener(){
 			@Override
 			public boolean onMenuItemClick(MenuItem item){

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HomeTabFragment.java
@@ -408,7 +408,7 @@ public class HomeTabFragment extends MastodonToolbarFragment implements Scrollab
 		addListsToOverflowMenu();
 		addHashtagsToOverflowMenu();
 
-		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI())
+		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI() && !UiUtils.isMagic())
 			m.setGroupDividerEnabled(true);
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
@@ -179,7 +179,7 @@ public class HeaderStatusDisplayItem extends StatusDisplayItem{
 
 			optionsMenu=new PopupMenu(activity, more);
 			optionsMenu.inflate(R.menu.post);
-			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI())
+			if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI() && !UiUtils.isMagic())
 				optionsMenu.getMenu().setGroupDividerEnabled(true);
 			optionsMenu.setOnMenuItemClickListener(menuItem->{
 				Account account=item.user;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -1530,6 +1530,10 @@ public class UiUtils {
 		return !TextUtils.isEmpty(getSystemProperty("ro.build.version.emui"));
 	}
 
+	public static boolean isMagic() {
+		return !TextUtils.isEmpty(getSystemProperty("ro.build.version.magic"));
+	}
+
 	public static int alphaBlendColors(int color1, int color2, float alpha) {
 		float alpha0 = 1f - alpha;
 		int r = Math.round(((color1 >> 16) & 0xFF) * alpha0 + ((color2 >> 16) & 0xFF) * alpha);

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
@@ -113,7 +113,7 @@ public class AccountViewHolder extends BindableViewHolder<AccountViewModel> impl
 		contextMenu.inflate(R.menu.profile);
 		contextMenu.setOnMenuItemClickListener(this::onContextMenuItemSelected);
 		menuButton.setOnClickListener(v->showMenuFromButton());
-		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI())
+		if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.P && !UiUtils.isEMUI() && !UiUtils.isMagic())
 			contextMenu.getMenu().setGroupDividerEnabled(true);
 		UiUtils.enablePopupMenuIcons(fragment.getContext(), contextMenu);
 


### PR DESCRIPTION
They have the same invisibility bug as EMUI.

[Example](https://vmst.io/@maikel/112583425285066680)