### PR TITLE
fix(HashtagTimelineFragment): display correct URL in recents menu

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -232,7 +232,7 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment{
 
 	@Override
 	public Uri getWebUri(Uri.Builder base) {
-		return base.path((isInstanceAkkoma() ? "/tag/" : "/tags/") + hashtag).build();
+		return base.path((isInstanceAkkoma() ? "/tag/" : "/tags/") + hashtagName).build();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes an issue, where the hashtag, instead of the hashtagName was displayed in the recents menu, causing the toString() function of the hashtag to be called, which inlcuded all the hashtag data, producing a faulty URL.