### PR TITLE
fix(AccountSwitcherSheet): only restart on different accounts

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountSwitcherSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/AccountSwitcherSheet.java
@@ -35,6 +35,7 @@ import org.joinmastodon.android.ui.views.CheckableRelativeLayout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -338,7 +339,8 @@ public class AccountSwitcherSheet extends BottomSheet{
 				onClick.accept(item.getID(), false);
 				return;
 			}
-			if(AccountSessionManager.getInstance().tryGetAccount(item.getID())!=null){
+			AccountSessionManager accountSessionManager=AccountSessionManager.getInstance();
+			if(accountSessionManager.tryGetAccount(item.getID())!=null && !Objects.equals(accountSessionManager.getLastActiveAccountID(), item.getID())){
 				AccountSessionManager.getInstance().setLastActiveAccountID(item.getID());
 				((MainActivity)activity).restartActivity();
 			}


### PR DESCRIPTION
Changes the AccountSwitcherSheet from always restarting the application to only restarting if a different account is selected. This reduces the friction of accidentally clicking on the same account.