### PR TITLE
feat(ErrorDisplayItem): improve UI/UX with new design

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -10,6 +10,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -379,7 +380,8 @@ public abstract class StatusDisplayItem{
 					: Collections.singletonList(warning)
 			);
 		} catch(Exception e) {
-			return new ArrayList<>(Collections.singletonList(new ErrorStatusDisplayItem(parentID, fragment, e)));
+			Log.e("StatusDisplayItem", "buildItems: failed to build StatusDisplayItem " + e);
+			return new ArrayList<>(Collections.singletonList(new ErrorStatusDisplayItem(parentID, statusForContent, fragment, e)));
 		}
 	}
 

--- a/mastodon/src/main/res/layout/display_item_error.xml
+++ b/mastodon/src/main/res/layout/display_item_error.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:layout_marginVertical="8dp"
+	android:layout_marginHorizontal="16dp"
+	android:padding="16dp"
+	android:clipToPadding="false"
+	android:background="@drawable/bg_settings_banner">
+
+	<ImageView
+		android:id="@+id/icon"
+		android:layout_width="40dp"
+		android:layout_height="40dp"
+		android:layout_marginEnd="16dp"
+		android:scaleType="center"
+		android:importantForAccessibility="no"
+		android:tint="?colorM3OnPrimaryContainer"
+		android:background="@drawable/white_circle"
+		android:backgroundTint="?colorM3PrimaryContainer"
+		android:src="@drawable/ic_fluent_warning_24_regular" />
+
+	<TextView
+		android:id="@+id/title"
+		android:layout_width="match_parent"
+		android:layout_height="24dp"
+		android:layout_toEndOf="@id/icon"
+		android:layout_marginBottom="2dp"
+		android:textAppearance="@style/m3_title_medium"
+		android:textColor="?colorM3OnSurface"
+		android:singleLine="true"
+		android:gravity="center_vertical"
+		android:text="@string/mo_error_display_title"/>
+
+	<TextView
+		android:id="@+id/text"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_toEndOf="@id/icon"
+		android:layout_below="@id/title"
+		android:textAppearance="@style/m3_body_medium"
+		android:minHeight="20dp"
+		android:gravity="center_vertical"
+		android:textColor="?colorM3OnSurface"
+		android:text="@string/mo_error_display_text"/>
+
+	<Button
+		android:id="@+id/button_open_browser"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_below="@id/text"
+		android:layout_toEndOf="@id/icon"
+		android:layout_marginStart="-16dp"
+		android:layout_marginBottom="-10dp"
+		style="@style/Widget.Mastodon.M3.Button.Text"
+		android:paddingStart="16dp"
+		android:paddingEnd="16dp"
+		android:minWidth="0dp"
+		android:text="@string/open_in_browser"
+		tools:text="@string/resume_notifications_now"/>
+
+	<Button
+		android:id="@+id/button_copy_error_details"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_below="@id/text"
+		android:layout_toEndOf="@id/button_open_browser"
+		android:layout_marginBottom="-10dp"
+		style="@style/Widget.Mastodon.M3.Button.Text"
+		android:paddingStart="16dp"
+		android:paddingEnd="16dp"
+		android:minWidth="0dp"
+		android:text="@string/mo_error_display_copy_error_details"/>
+
+</RelativeLayout>

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -133,4 +133,9 @@
 	<string name="export_settings_summary">Export all logged-in accounts\' settings and timelines</string>
 	<string name="import_settings_title">Import settings</string>
 	<string name="import_settings_summary">Import previously exported settings and timelines</string>
+
+	<!-- error display item	-->
+	<string name="mo_error_display_title">Failed to display post</string>
+	<string name="mo_error_display_text">Something went wrong while loading this post. If the problem persists, please report it on our Issues page along with the error details.</string>
+	<string name="mo_error_display_copy_error_details">Copy details</string>
 </resources>


### PR DESCRIPTION
Updates the design of the ErrorStatusDisplayItem to be more user-friendly. The new design displays an error message indicating that an error has occurred while attempting to display the item. It then offers the choice of either view the item in the browser or copy the error details.

![New ErrorStatusItem](https://github.com/LucasGGamerM/moshidon/assets/63370021/a730ea8d-5f44-48e8-afd5-8776e8f7b2ca)

<details><summary>Example of copied error details</summary>
<p>

```
App Version: Moshidon v2.3.0+fork.105.moshinda-debug (105)
OS Version: Android 14
Status URL: https://mastodon.thenewoil.org/@thenewoil/112610734700259723
Exception: java.lang.IllegalArgumentException
	at org.joinmastodon.android.ui.displayitems.StatusDisplayItem.buildItems(StatusDisplayItem.java:170)
	at org.joinmastodon.android.fragments.StatusListFragment.buildDisplayItems(StatusListFragment.java:64)
	at org.joinmastodon.android.fragments.StatusListFragment.buildDisplayItems(StatusListFragment.java:49)
	at org.joinmastodon.android.fragments.BaseStatusListFragment.onAppendItems(BaseStatusListFragment.java:143)
	at me.grishka.appkit.utils.Preloader.onDataLoaded(Preloader.java:86)
	at me.grishka.appkit.fragments.BaseRecyclerFragment.onDataLoaded(BaseRecyclerFragment.java:331)
	at org.joinmastodon.android.fragments.BaseStatusListFragment.onDataLoaded(BaseStatusListFragment.java:1119)
	at org.joinmastodon.android.fragments.HomeTimelineFragment$1.onSuccess(HomeTimelineFragment.java:63)
	at org.joinmastodon.android.fragments.HomeTimelineFragment$1.onSuccess(HomeTimelineFragment.java:56)
	at org.joinmastodon.android.api.CacheController$1.onSuccess(CacheController.java:101)
	at org.joinmastodon.android.api.CacheController$1.onSuccess(CacheController.java:98)
	at me.grishka.appkit.api.APIRequest$1.run(APIRequest.java:29)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8177)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

</p>
</details> 