### PR TITLE
fix(ErrorStatusDisplayItem): disable open in browser button on null URL

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ErrorStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ErrorStatusDisplayItem.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
 import org.joinmastodon.android.BuildConfig;
 import org.joinmastodon.android.R;
@@ -32,7 +33,9 @@ public class ErrorStatusDisplayItem extends StatusDisplayItem{
 
 		public Holder(Context context, ViewGroup parent) {
 			super(context, R.layout.display_item_error, parent);
-			findViewById(R.id.button_open_browser).setOnClickListener(v -> UiUtils.launchWebBrowser(v.getContext(), item.status.url));
+			Button openInBrowserButton=findViewById(R.id.button_open_browser);
+			openInBrowserButton.setEnabled(item.status.url!=null);
+			openInBrowserButton.setOnClickListener(v -> UiUtils.launchWebBrowser(v.getContext(), item.status.url));
 			findViewById(R.id.button_copy_error_details).setOnClickListener(this::copyErrorDetails);
 		}
 


### PR DESCRIPTION
Fixes an issue in https://github.com/LucasGGamerM/moshidon/pull/426, where the app would crash, if the URL was null. To prevent that, the Open in Browser is disabled if the URL is null. This should however only be rarely the case.