### PR TITLE
fix(StatusDisplayItem): explictly copy filter list

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -230,7 +230,7 @@ public abstract class StatusDisplayItem{
 
 			LegacyFilter applyingFilter=null;
 			if(status.filtered!=null){
-				List<FilterResult> filters=status.filtered;
+				ArrayList<FilterResult> filters= new ArrayList<>(status.filtered);
 
 				// Only add client filters if there are no pre-existing status filter
 				if(filters.isEmpty())


### PR DESCRIPTION
Hopefully fixes an issue, where the app could not [display scheduled statuses](https://mastodon.social/@iThreepwood/112597310727750819). Unfortunately I'm not able to reproduce this error on my emulator, so I wasn't able to test it.