### PR TITLE
feat(Notification) add remove from followers action

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -133,20 +133,24 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 
 			if(intent.hasExtra("notification")){
 				org.joinmastodon.android.model.Notification notification=Parcels.unwrap(intent.getParcelableExtra("notification"));
+				if(notification==null){
+					Log.e(TAG, "onReceive: Failed to notification");
+					return;
+				}
 
 				String statusID = null;
-				if(notification != null && notification.status != null)
+				if(notification.status != null)
 					statusID=notification.status.id;
 
-				if (statusID != null) {
+				if (statusID!=null || notification.account!=null) {
 					AccountSessionManager accountSessionManager = AccountSessionManager.getInstance();
 					Preferences preferences = accountSessionManager.getAccount(accountID).preferences;
 
 					switch (NotificationAction.values()[intent.getIntExtra("notificationAction", 0)]) {
 						case FAVORITE -> new SetStatusFavorited(statusID, true).exec(accountID);
 						case BOOKMARK -> new SetStatusBookmarked(statusID, true).exec(accountID);
-						case BOOST -> new SetStatusReblogged(notification.status.id, true, preferences.postingDefaultVisibility).exec(accountID);
-						case UNBOOST -> new SetStatusReblogged(notification.status.id, false, preferences.postingDefaultVisibility).exec(accountID);
+						case BOOST -> new SetStatusReblogged(statusID, true, preferences.postingDefaultVisibility).exec(accountID);
+						case UNBOOST -> new SetStatusReblogged(statusID, false, preferences.postingDefaultVisibility).exec(accountID);
 						case REPLY -> handleReplyAction(context, accountID, intent, notification, notificationId, preferences);
 						case FOLLOW_BACK -> new SetAccountFollowed(notification.account.id, true, true, false).exec(accountID);
 						default -> Log.w(TAG, "onReceive: Failed to get NotificationAction");

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -21,6 +21,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import org.joinmastodon.android.api.MastodonAPIController;
+import org.joinmastodon.android.api.requests.accounts.RemoveFromFollowers;
 import org.joinmastodon.android.api.requests.accounts.SetAccountFollowed;
 import org.joinmastodon.android.api.requests.notifications.GetNotificationByID;
 import org.joinmastodon.android.api.requests.statuses.CreateStatus;
@@ -153,6 +154,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 						case UNBOOST -> new SetStatusReblogged(statusID, false, preferences.postingDefaultVisibility).exec(accountID);
 						case REPLY -> handleReplyAction(context, accountID, intent, notification, notificationId, preferences);
 						case FOLLOW_BACK -> new SetAccountFollowed(notification.account.id, true, true, false).exec(accountID);
+						case REMOVE_FOLLOWER -> new RemoveFromFollowers(notification.account.id).exec(accountID);
 						default -> Log.w(TAG, "onReceive: Failed to get NotificationAction");
 					}
 				}
@@ -283,6 +285,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 				}
 				case FOLLOW -> {
 					builder.addAction(buildNotificationAction(context, id, accountID, notification, context.getString(R.string.follow_back), NotificationAction.FOLLOW_BACK));
+					builder.addAction(buildNotificationAction(context, id, accountID, notification, context.getString(R.string.mo_notification_action_remove_follower), NotificationAction.REMOVE_FOLLOWER));
 				}
 			}
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/RemoveFromFollowers.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/RemoveFromFollowers.java
@@ -1,0 +1,11 @@
+package org.joinmastodon.android.api.requests.accounts;
+
+import org.joinmastodon.android.api.MastodonAPIRequest;
+import org.joinmastodon.android.model.Relationship;
+
+public class RemoveFromFollowers extends MastodonAPIRequest<Relationship>{
+    public RemoveFromFollowers(String id){
+        super(HttpMethod.POST, "/follow_requests/"+id+"/reject", Relationship.class);
+        setRequestBody(new Object());
+    }
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/RemoveFromFollowers.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/accounts/RemoveFromFollowers.java
@@ -5,7 +5,7 @@ import org.joinmastodon.android.model.Relationship;
 
 public class RemoveFromFollowers extends MastodonAPIRequest<Relationship>{
     public RemoveFromFollowers(String id){
-        super(HttpMethod.POST, "/follow_requests/"+id+"/reject", Relationship.class);
+        super(HttpMethod.POST, "/accounts/"+id+"/remove_from_followers", Relationship.class);
         setRequestBody(new Object());
     }
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/NotificationAction.java
@@ -6,5 +6,6 @@ public enum NotificationAction {
     UNBOOST,
     BOOKMARK,
     REPLY,
-    FOLLOW_BACK
+	FOLLOW_BACK,
+	REMOVE_FOLLOWER
 }

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -139,4 +139,6 @@
 	<string name="mo_error_display_text">Something went wrong while loading this post. If the problem persists, please report it on our Issues page along with the error details.</string>
 	<string name="mo_error_display_copy_error_details">Copy details</string>
 	<string name="mo_trending_link_read">Read</string>
+
+	<string name="mo_notification_action_remove_follower">Remove from Followers</string>
 </resources>


### PR DESCRIPTION
Adds a new "Remove from Followers" notification action, that allows to immediately remove a new follower from the notification.

Also fixes a bug, where account related notification actions were never executed.

![Notification with new action](https://github.com/LucasGGamerM/moshidon/assets/63370021/bd2118a8-ade4-4c4f-90ab-5cf78e2225f0)
