### PR TITLE
Fix/mastodon social redirect

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/LinkCardStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/LinkCardStatusDisplayItem.java
@@ -146,18 +146,18 @@ public class LinkCardStatusDisplayItem extends StatusDisplayItem{
 			String url=item.status.card.url;
 			// Mastodon.social sometimes adds an additional redirect page
 			// this is really disruptive on mobile, especially since it breaks the loopUp/openURL functionality
-			if(url.startsWith("https://mastodon.social/redirect/statuses/")){
-				Uri parsedURL=Uri.parse(url);
+			Uri parsedURL=Uri.parse(url);
+			if(parsedURL.getPath()!=null && parsedURL.getPath().startsWith("/redirect/statuses/")){
 				// find actually linked url in status content
 				Matcher matcher=HtmlParser.URL_PATTERN.matcher(item.status.content);
 				String foundURL;
-				while(matcher.find() && parsedURL.getLastPathSegment()!=null){
+				while(matcher.find()){
 					foundURL=matcher.group(3);
 					if(TextUtils.isEmpty(matcher.group(4)))
 						foundURL="http://"+foundURL;
 					// SAFETY: Cannot be null, as otherwise the matcher wouldn't find it
 					// also, group is marked as non-null
-					assert foundURL!=null;
+					assert foundURL!=null && parsedURL.getLastPathSegment()!=null;
 					if(foundURL.endsWith(parsedURL.getLastPathSegment())) {
 						// found correct URL
 						url=foundURL;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -1482,7 +1482,7 @@ public class UiUtils {
 									return;
 								}
 								Optional<Account> account = results.accounts.stream()
-										.filter(a -> uri.equals(Uri.parse(a.url))).findAny();
+										.filter(a -> uri.getPath().contains(a.getFullyQualifiedName())).findAny();
 								if (account.isPresent()) {
 									args.putParcelable("profileAccount", Parcels.wrap(account.get()));
 									go.accept(ProfileFragment.class, args);


### PR DESCRIPTION
On other servers, mastodon.social may add a link card that leads to a redirect warning page. This can be quite annoying in a mobile app, as well as breaking the in-app `openURL` functionality.
This pr changes it so that the original link is opened instead (i.e. how it works on other servers with normal link cards).

![Redirect Warning on Mastodon.social](https://github.com/LucasGGamerM/moshidon/assets/63370021/05ce0706-eeaa-4392-9bae-63a50ffa50fa)
