### PR TITLE
fix(HtmlParser): remove trailing line breaks

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -123,6 +123,9 @@ public class HtmlParser{
 		int colorInsert=UiUtils.getThemeColor(context, R.attr.colorM3Success);
 		int colorDelete=UiUtils.getThemeColor(context, R.attr.colorM3Error);
 
+		if(source.endsWith("\n"))
+			source=source.stripTrailing();
+
 		Jsoup.parseBodyFragment(source).body().traverse(new NodeVisitor(){
 			private final ArrayList<SpanInfo> openSpans=new ArrayList<>();
 


### PR DESCRIPTION
Some fediverse servers (e.g. lemmy) add a trailing line break to the content. Since we add them as well, this can cause up to three line breaks at the end of a post, resulting in a blank space. This removes the trailing line breaks before parsing the content.

| Before                                                                                                                                       	| After                                                                                                                      	|
|----------------------------------------------------------------------------------------------------------------------------------------------	|----------------------------------------------------------------------------------------------------------------------------	|
| ![Post with a visible blank space at the end](https://github.com/LucasGGamerM/moshidon/assets/63370021/f8549ced-4014-4aeb-af8e-2ebf2586fc4e) 	| ![Post with no blank space](https://github.com/LucasGGamerM/moshidon/assets/63370021/be550665-2970-4203-9c49-43cfc30afbf5) 	|