### PR TITLE
feat: use AccountSwitcherSheet for account picker

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -42,7 +42,11 @@ public class ExternalShareActivity extends FragmentStackActivity{
 				Toast.makeText(this, R.string.err_not_logged_in, Toast.LENGTH_SHORT).show();
 				finish();
 			} else if (isOpenable || sessions.size() > 1) {
-				AccountSwitcherSheet sheet = new AccountSwitcherSheet(this, null, true, isOpenable);
+				AccountSwitcherSheet sheet = new AccountSwitcherSheet(this, null, R.drawable.ic_fluent_share_28_regular,
+						isOpenable
+								? R.string.sk_external_share_or_open_title
+								: R.string.sk_external_share_title,
+						null, isOpenable);
 				sheet.setOnClick((accountId, open) -> {
 					if (open && text.isPresent()) {
 						BiConsumer<Class<? extends Fragment>, Bundle> callback = (clazz, args) -> {

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -131,6 +131,7 @@ import org.joinmastodon.android.model.Searchable;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.ui.M3AlertDialogBuilder;
 import org.joinmastodon.android.ui.Snackbar;
+import org.joinmastodon.android.ui.sheets.AccountSwitcherSheet;
 import org.joinmastodon.android.ui.sheets.BlockAccountConfirmationSheet;
 import org.joinmastodon.android.ui.sheets.MuteAccountConfirmationSheet;
 import org.joinmastodon.android.ui.text.CustomEmojiSpan;
@@ -1213,18 +1214,9 @@ public class UiUtils {
 	}
 
 	public static void pickAccount(Context context, String exceptFor, @StringRes int titleRes, @DrawableRes int iconRes, Consumer<AccountSession> sessionConsumer, Consumer<AlertDialog.Builder> transformDialog) {
-		List<AccountSession> sessions = AccountSessionManager.getInstance().getLoggedInAccounts()
-				.stream().filter(s -> !s.getID().equals(exceptFor)).collect(Collectors.toList());
-
-		AlertDialog.Builder builder = new M3AlertDialogBuilder(context)
-				.setItems(
-						sessions.stream().map(AccountSession::getFullUsername).toArray(String[]::new),
-						(dialog, which) -> sessionConsumer.accept(sessions.get(which))
-				)
-				.setTitle(titleRes == 0 ? R.string.choose_account : titleRes)
-				.setIcon(iconRes);
-		if (transformDialog != null) transformDialog.accept(builder);
-		builder.show();
+		AccountSwitcherSheet sheet = new AccountSwitcherSheet((Activity) context, null, iconRes, titleRes == 0 ? R.string.choose_account : titleRes, exceptFor, false);
+		sheet.setOnClick((accountId, open) ->sessionConsumer.accept(AccountSessionManager.get(accountId)));
+		sheet.show();
 	}
 
 	public static void restartApp() {


### PR DESCRIPTION
Uses the `AccountSwitcherSheet` as an account picker when choosing an account to interact with a status.

![Screenshot from 2024-07-04 20-52-35](https://github.com/LucasGGamerM/moshidon/assets/63370021/5b93e8e2-2829-4ff0-a237-1b3e8c994ce0)


see https://github.com/sk22/megalodon/issues/600