### PR TITLE
fix(StatusDisplayItem): check if headerlist is empty

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/BaseStatusListFragment.java
@@ -796,8 +796,10 @@ public abstract class BaseStatusListFragment<T extends DisplayItemsParent> exten
 		if(s.textExpandable!=expandable && list!=null) {
 			s.textExpandable=expandable;
 			List<HeaderStatusDisplayItem.Holder> headers=findAllHoldersOfType(holder.getItemID(), HeaderStatusDisplayItem.Holder.class);
-			HeaderStatusDisplayItem.Holder header=headers.size() > 1 && isForQuote ? headers.get(1) : headers.get(0);
-			if(header!=null) header.bindCollapseButton();
+			if(headers!=null && !headers.isEmpty()){
+				HeaderStatusDisplayItem.Holder header=headers.size() > 1 && isForQuote ? headers.get(1) : headers.get(0);
+				if(header!=null) header.bindCollapseButton();
+			}
 		}
 	}
 


### PR DESCRIPTION
Likely fixes an `java.lang.IndexOutOfBoundsException` crash introduced in https://github.com/LucasGGamerM/moshidon/commit/38df70cd9ecbacbd55f53ac0f6d1d3f0eea1d5db.