### PR TITLE
fix: show profile picture in share sheet

### DIFF
--- a/mastodon/src/main/AndroidManifest.xml
+++ b/mastodon/src/main/AndroidManifest.xml
@@ -106,16 +106,6 @@
 		</receiver>
 
 		<provider
-			android:name="org.joinmastodon.android.utils.FileProvider"
-			android:authorities="${applicationId}.fileprovider"
-			android:exported="false"
-			android:grantUriPermissions="true">
-			<meta-data
-				android:name="android.support.FILE_PROVIDER_PATHS"
-				android:resource="@xml/file_paths" />
-		</provider>
-
-		<provider
 			android:authorities="${applicationId}.fileprovider"
 			android:name=".TweakedFileProvider"
 			android:grantUriPermissions="true"

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -1769,9 +1769,9 @@ public class UiUtils {
 		ImageCache cache=ImageCache.getInstance(context);
 		try{
 			File ava=cache.getFile(new UrlImageLoaderRequest(account.avatarStatic));
-			if(!ava.exists())
+			if(ava==null || !ava.exists())
 				ava=cache.getFile(new UrlImageLoaderRequest(account.avatar));
-			if(ava.exists()){
+			if(ava!=null && ava.exists()){
 				intent.setClipData(ClipData.newRawUri(null, getFileProviderUri(context, ava)));
 				intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 			}


### PR DESCRIPTION
Shows the profile picture of the shared account in the share sheet. This was already done upstream and intended here, but was bugged due to an additional file provider.

![Sharesheet with account picture](https://github.com/LucasGGamerM/moshidon/assets/63370021/a1d61ced-7b19-409b-9d28-8a2a01d8e482)
