### PR TITLE
feat: apply inset to filter warning

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/model/AltTextFilter.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/AltTextFilter.java
@@ -1,6 +1,8 @@
 package org.joinmastodon.android.model;
 
 import org.joinmastodon.android.GlobalUserPreferences;
+import org.joinmastodon.android.MastodonApp;
+import org.joinmastodon.android.R;
 import org.jsoup.internal.StringUtil;
 
 import java.util.EnumSet;
@@ -8,9 +10,10 @@ import java.util.EnumSet;
 public class AltTextFilter extends LegacyFilter {
 
 	public AltTextFilter(FilterAction filterAction, EnumSet<FilterContext> filterContexts) {
-		this.filterAction = filterAction;
-		isRemote = false;
-		context = filterContexts;
+		this.filterAction=filterAction;
+		this.title=MastodonApp.context.getString(R.string.sk_no_alt_text);
+		this.isRemote=false;
+		this.context=filterContexts;
 	}
 
 	@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -396,6 +396,8 @@ public abstract class StatusDisplayItem{
 			List<StatusDisplayItem> nonGapItems=gap!=null ? items.subList(0, items.size()-1) : items;
 			WarningFilteredStatusDisplayItem warning=applyingFilter==null ? null :
 					new WarningFilteredStatusDisplayItem(parentID, fragment, statusForContent, nonGapItems, applyingFilter);
+			if(warning!=null)
+				warning.inset=inset;
 			return applyingFilter==null ? items : new ArrayList<>(gap!=null
 					? List.of(warning, gap)
 					: Collections.singletonList(warning)

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/WarningFilteredStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/WarningFilteredStatusDisplayItem.java
@@ -52,13 +52,13 @@ public class WarningFilteredStatusDisplayItem extends StatusDisplayItem{
 			String title=item.applyingFilter.title;
 			text.setText(item.parentFragment.getString(R.string.sk_filtered, title));
 
-			itemView.setClipToOutline(item.inset);
-			itemView.setOutlineProvider(item.inset ? OutlineProviders.roundedRect(12) : null);
+			if(item.inset){
+				itemView.setClipToOutline(true);
+				itemView.setOutlineProvider(OutlineProviders.roundedRect(12));
+			}
 		}
 
 		@Override
-		public void onClick(){
-
-		}
+		public void onClick(){}
 	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/WarningFilteredStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/WarningFilteredStatusDisplayItem.java
@@ -8,14 +8,11 @@ import android.widget.TextView;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
-import org.joinmastodon.android.model.AltTextFilter;
-import org.joinmastodon.android.model.Filter;
 import org.joinmastodon.android.model.LegacyFilter;
 import org.joinmastodon.android.model.Status;
 
 import java.util.List;
 
-// Mind the gap!
 public class WarningFilteredStatusDisplayItem extends StatusDisplayItem{
 	public boolean loading;
 	public List<StatusDisplayItem> filteredItems;
@@ -24,8 +21,8 @@ public class WarningFilteredStatusDisplayItem extends StatusDisplayItem{
 	public WarningFilteredStatusDisplayItem(String parentID, BaseStatusListFragment<?> parentFragment, Status status, List<StatusDisplayItem> filteredItems, LegacyFilter applyingFilter){
 		super(parentID, parentFragment);
 		this.status=status;
-		this.filteredItems = filteredItems;
-		this.applyingFilter = applyingFilter;
+		this.filteredItems=filteredItems;
+		this.applyingFilter=applyingFilter;
 	}
 
 	@Override
@@ -33,31 +30,31 @@ public class WarningFilteredStatusDisplayItem extends StatusDisplayItem{
 		return Type.WARNING;
 	}
 
-    public static class Holder extends StatusDisplayItem.Holder<WarningFilteredStatusDisplayItem>{
-        public final View warningWrap;
-        public final Button showBtn;
-        public final TextView text;
-        public List<StatusDisplayItem> filteredItems;
+	public static class Holder extends StatusDisplayItem.Holder<WarningFilteredStatusDisplayItem>{
+		public final View warningWrap;
+		public final Button showBtn;
+		public final TextView text;
+		public List<StatusDisplayItem> filteredItems;
 
-        public Holder(Context context, ViewGroup parent){
-            super(context, R.layout.display_item_warning, parent);
-            warningWrap=findViewById(R.id.warning_wrap);
-            showBtn=findViewById(R.id.reveal_btn);
-            showBtn.setOnClickListener(i -> item.parentFragment.onWarningClick(this));
-            itemView.setOnClickListener(v->item.parentFragment.onWarningClick(this));
-            text=findViewById(R.id.text);
-        }
+		public Holder(Context context, ViewGroup parent){
+			super(context, R.layout.display_item_warning, parent);
+			warningWrap=findViewById(R.id.warning_wrap);
+			showBtn=findViewById(R.id.reveal_btn);
+			showBtn.setOnClickListener(i->item.parentFragment.onWarningClick(this));
+			itemView.setOnClickListener(v->item.parentFragment.onWarningClick(this));
+			text=findViewById(R.id.text);
+		}
 
 		@Override
-		public void onBind(WarningFilteredStatusDisplayItem item) {
-			filteredItems = item.filteredItems;
-			String title = item.applyingFilter instanceof AltTextFilter ? item.parentFragment.getString(R.string.sk_no_alt_text) : item.applyingFilter.title;
+		public void onBind(WarningFilteredStatusDisplayItem item){
+			filteredItems=item.filteredItems;
+			String title=item.applyingFilter.title;
 			text.setText(item.parentFragment.getString(R.string.sk_filtered, title));
 		}
 
-        @Override
-        public void onClick(){
+		@Override
+		public void onClick(){
 
-        }
-    }
+		}
+	}
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/WarningFilteredStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/WarningFilteredStatusDisplayItem.java
@@ -10,6 +10,7 @@ import org.joinmastodon.android.R;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.model.LegacyFilter;
 import org.joinmastodon.android.model.Status;
+import org.joinmastodon.android.ui.OutlineProviders;
 
 import java.util.List;
 
@@ -50,6 +51,9 @@ public class WarningFilteredStatusDisplayItem extends StatusDisplayItem{
 			filteredItems=item.filteredItems;
 			String title=item.applyingFilter.title;
 			text.setText(item.parentFragment.getString(R.string.sk_filtered, title));
+
+			itemView.setClipToOutline(item.inset);
+			itemView.setOutlineProvider(item.inset ? OutlineProviders.roundedRect(12) : null);
 		}
 
 		@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/InsetStatusItemDecoration.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/InsetStatusItemDecoration.java
@@ -11,6 +11,7 @@ import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.ui.displayitems.StatusDisplayItem;
 import org.joinmastodon.android.ui.displayitems.LinkCardStatusDisplayItem;
 import org.joinmastodon.android.ui.displayitems.MediaGridStatusDisplayItem;
+import org.joinmastodon.android.ui.displayitems.WarningFilteredStatusDisplayItem;
 
 import java.util.List;
 
@@ -42,13 +43,16 @@ public class InsetStatusItemDecoration extends RecyclerView.ItemDecoration{
 			boolean inset=(holder instanceof StatusDisplayItem.Holder<?> sdi) && sdi.getItem().inset;
 			if(inset){
 				if(rect.isEmpty()){
-					if(holder instanceof MediaGridStatusDisplayItem.Holder || holder instanceof LinkCardStatusDisplayItem.Holder){
-						rect.set(child.getX(), i == 0 && pos > 0 && displayItems.get(pos - 1).inset ? V.dp(-10) : child.getY(), child.getX() + child.getWidth(), child.getY() + child.getHeight() + V.dp(4));
+					if(holder instanceof MediaGridStatusDisplayItem.Holder || holder instanceof LinkCardStatusDisplayItem.Holder || holder instanceof WarningFilteredStatusDisplayItem.Holder){
+						float topInset=i == 0 && pos > 0 && displayItems.get(pos - 1).inset ? V.dp(-10) : child.getY();
+						if(holder instanceof WarningFilteredStatusDisplayItem.Holder)
+							topInset-=V.dp(4);
+						rect.set(child.getX(), topInset, child.getX() + child.getWidth(), child.getY() + child.getHeight() + V.dp(4));
 					}else {
 						rect.set(child.getX(), i == 0 && pos > 0 && displayItems.get(pos - 1).inset ? V.dp(-10) : child.getY(), child.getX() + child.getWidth(), child.getY() + child.getHeight());
 					}
 				}else{
-					if(holder instanceof MediaGridStatusDisplayItem.Holder || holder instanceof LinkCardStatusDisplayItem.Holder){
+					if(holder instanceof MediaGridStatusDisplayItem.Holder || holder instanceof LinkCardStatusDisplayItem.Holder || holder instanceof WarningFilteredStatusDisplayItem.Holder){
 						rect.bottom=Math.max(rect.bottom, child.getY()+child.getHeight()) + V.dp(4);
 					}else {
 						rect.bottom=Math.max(rect.bottom, child.getY()+child.getHeight());

--- a/mastodon/src/main/res/layout/display_item_warning.xml
+++ b/mastodon/src/main/res/layout/display_item_warning.xml
@@ -29,8 +29,7 @@
 		android:layout_weight="1"
         android:singleLine="true"
         android:ellipsize="end"
-        android:visibility="visible"
-        />
+        android:visibility="visible"/>
 
 
 </LinearLayout>


### PR DESCRIPTION
Applies the inset to the `WarningFilteredStatusDisplayItem`, allowing it to display the inset for quotes, making it easier to distinguish between the actual status and the filtered quote.

| Before                                                                                                                             	| After                                                                                                                                	|
|------------------------------------------------------------------------------------------------------------------------------------	|--------------------------------------------------------------------------------------------------------------------------------------	|
| ![WarningFilteredStatusDisplayItem without inset](https://github.com/user-attachments/assets/8a3e5a38-9918-4451-891a-ab63f39d03f6) 	| ![WarningFilteredStatusDisplayItem correctly inset](https://github.com/user-attachments/assets/1eef7521-c6f1-4b58-b155-b5b6ecc391b5) 	|