### PR TITLE
fix: check if uri is hierarchical

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsAboutAppFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsAboutAppFragment.java
@@ -94,7 +94,7 @@ public class SettingsAboutAppFragment extends BaseSettingsFragment<Void> impleme
 				copyCrashLogItem=new ListItem<>(getString(R.string.sk_settings_copy_crash_log), lastModified, 0, this::onCopyCrashLog)
 		));
 
-		if(GithubSelfUpdater.needSelfUpdating()){
+		if(GithubSelfUpdater.needSelfUpdating() && !BuildConfig.BUILD_TYPE.equals("nightly") ){
 			items.add(enablePreReleasesItem=new CheckableListItem<>(R.string.sk_updater_enable_pre_releases, 0, CheckableListItem.Style.SWITCH, GlobalUserPreferences.enablePreReleases, i->toggleCheckableItem(enablePreReleasesItem)));
 		}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/utils/Tracking.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/Tracking.java
@@ -64,7 +64,7 @@ public class Tracking{
 	@NonNull
 	public static String removeTrackingParameters(@NonNull String url){
 		Uri uri=Uri.parse(url);
-		if(uri==null)
+		if(uri==null || !uri.isHierarchical())
 			return url;
 		Uri.Builder uriBuilder=uri.buildUpon().clearQuery();
 


### PR DESCRIPTION
Fixes a regression in 34f3e33efc06ec4ebf91a5ba02feccc82dc69bbb, which caused to copy crash log setting to crash. It can be mitigated by checking if the given URI is hierarchical, as otherwise the `getQueryParameterNames` function will throw an exception.