### PR TITLE
feat(Quote): hide quotes of accounts that are muted/blocked or filtered.

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -20,6 +20,7 @@ import org.joinmastodon.android.R;
 import org.joinmastodon.android.api.requests.accounts.GetAccountRelationships;
 import org.joinmastodon.android.api.requests.search.GetSearchResults;
 import org.joinmastodon.android.api.session.AccountLocalPreferences;
+import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.fragments.BaseStatusListFragment;
 import org.joinmastodon.android.fragments.HashtagTimelineFragment;
@@ -449,7 +450,8 @@ public abstract class StatusDisplayItem{
 									return;
 
 								Relationship relationship=relationships.get(0);
-								if(relationship.domainBlocking || relationship.muting || relationship.blocking) {
+								String selfId=AccountSessionManager.get(accountID).self.id;
+								if(!status.account.id.equals(selfId) && (relationship.domainBlocking || relationship.muting || relationship.blocking)) {
 									// do not show posts that are quoting a muted/blocked user
 									fragment.removeStatus(status);
 									return;

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -339,7 +339,7 @@ public abstract class StatusDisplayItem{
 					contentItems.add(new DummyStatusDisplayItem(parentID, fragment));
 				contentItems.addAll(buildItems(fragment, statusForContent.quote, accountID, parentObject, knownAccounts, filterContext, FLAG_NO_FOOTER|FLAG_INSET|FLAG_NO_EMOJI_REACTIONS|FLAG_IS_FOR_QUOTE));
 			} else if((flags & FLAG_INSET)==0 && statusForContent.mediaAttachments.isEmpty()){
-				tryAddNonOfficialQuote(statusForContent, fragment, accountID);
+				tryAddNonOfficialQuote(statusForContent, fragment, accountID, filterContext);
 			}
 			if(contentItems!=items && statusForContent.spoilerRevealed){
 				items.addAll(contentItems);
@@ -421,7 +421,7 @@ public abstract class StatusDisplayItem{
 	 * Tries to adds a non-official quote to a status.
 	 * A non-official quote is a quote on an instance that does not support quotes officially.
 	 */
-	private static void tryAddNonOfficialQuote(Status status, BaseStatusListFragment fragment, String accountID) {
+	private static void tryAddNonOfficialQuote(Status status, BaseStatusListFragment fragment, String accountID, FilterContext filterContext) {
 		Matcher matcher=QUOTE_PATTERN.matcher(status.getStrippedText());
 
 		if(!matcher.find())
@@ -432,6 +432,7 @@ public abstract class StatusDisplayItem{
 			new GetSearchResults(quoteURL, GetSearchResults.Type.STATUSES, true, null, 0, 0).setCallback(new Callback<>(){
 				@Override
 				public void onSuccess(SearchResults results){
+					AccountSessionManager.get(accountID).filterStatuses(results.statuses, filterContext);
 					if (!results.statuses.isEmpty()){
 						status.quote=results.statuses.get(0);
 						fragment.updateStatusWithQuote(status);


### PR DESCRIPTION
Updates the non-official quotes to completely hide the post of the account of the quote is muted or blocked. This is consistent with other platform with native quotes like Misskey, as well as Mastodon mutes/blocks.

Closes https://github.com/LucasGGamerM/moshidon/issues/488