### PR TITLE
fix(Discover): switch post and hashtag fragments everywhere

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverFragment.java
@@ -260,8 +260,8 @@ public class DiscoverFragment extends AppKitFragment implements ScrollableToTop,
 
 	private Fragment getFragmentForPage(int page){
 		return switch(page){
-			case 0 -> hashtagsFragment;
-			case 1 -> postsFragment;
+			case 0 -> postsFragment;
+			case 1 -> hashtagsFragment;
 			case 2 -> newsFragment;
 			case 3 -> accountsFragment;
 			default -> throw new IllegalStateException("Unexpected value: "+page);


### PR DESCRIPTION
Fixes a regression in 5edbe9b82666e17c0f103678da6209ef7e9eaf17, whcih did not switch the fragments everywhere. This caused the scroll-to-top functionality to not work and the posts to not immediatly load.

Closes https://github.com/LucasGGamerM/moshidon/issues/483.