### PR TITLE
feat(Timeline/TrendingLinks): display URL, update icon

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverTrendingLinkTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/discover/DiscoverTrendingLinkTimelineFragment.java
@@ -131,8 +131,7 @@ public class DiscoverTrendingLinkTimelineFragment extends StatusListFragment{
 
 	@Override
 	public Uri getWebUri(Uri.Builder base) {
-		//TODO: add URL link once web version implements a UI
-		return base.path("/explore/links").build();
+		return base.path("/links").appendPath(trendingLink.url).build();
 	}
 
 	@Override

--- a/mastodon/src/main/res/drawable/ic_fluent_document_one_page_24_filled.xml
+++ b/mastodon/src/main/res/drawable/ic_fluent_document_one_page_24_filled.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:pathData="M17.75,2.007a2.25,2.25 0,0 1,2.245 2.096l0.005,0.154v15.498A2.25,2.25 0,0 1,17.904 22l-0.154,0.005H6.25a2.25,2.25 0,0 1,-2.245 -2.096L4,19.755V4.257a2.25,2.25 0,0 1,2.096 -2.245l0.154,-0.005h11.5ZM7.75,7a0.75,0.75 0,1 0,0 1.5h8.5a0.75,0.75 0,0 0,0 -1.5h-8.5ZM7,11.75c0,0.414 0.336,0.75 0.75,0.75h8.5a0.75,0.75 0,0 0,0 -1.5h-8.5a0.75,0.75 0,0 0,-0.75 0.75ZM7.75,15a0.75,0.75 0,1 0,0 1.5h8.5a0.75,0.75 0,0 0,0 -1.5h-8.5Z"
-      android:fillColor="#212121"/>
-</vector>

--- a/mastodon/src/main/res/menu/trending_links_timeline.xml
+++ b/mastodon/src/main/res/menu/trending_links_timeline.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/open_link"
-        android:icon="@drawable/ic_fluent_document_one_page_24_filled"
+        android:icon="@drawable/ic_fluent_open_24_regular"
         android:showAsAction="always"
         android:title="@string/mo_trending_link_read"/>
 </menu>


### PR DESCRIPTION
Updates the TrendingLink Timeline to display the correct URL (now that the web version has a UI) and updates the icon of the Read action. The previous icon made it hard to recognize what the action was supposed to do. Additionally, the new one also indicates that it will take the user to an external website.

![Timeline header with new icon](https://github.com/user-attachments/assets/1695b16a-5bf1-4121-bcfc-b4dadd1b7e0f)
