### PR TITLE
fix(ExternalShareActivity): set theme before opening compose

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ExternalShareActivity.java
@@ -86,6 +86,8 @@ public class ExternalShareActivity extends FragmentStackActivity{
 	}
 
 	private void openComposeFragment(String accountID){
+		AccountSession session=AccountSessionManager.get(accountID);
+		UiUtils.setUserPreferredTheme(this, session);
 		getWindow().setBackgroundDrawable(null);
 
 		Intent intent=getIntent();


### PR DESCRIPTION
Fixes https://github.com/sk22/megalodon/issues/926.