### PR TITLE
feat(Profile): display Toast when saving note

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -468,6 +468,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 			public void onSuccess(Relationship result) {
 				updateRelationship(result);
 				invalidateOptionsMenu();
+				Toast.makeText(getContext(), R.string.mo_personal_note_saved, Toast.LENGTH_SHORT).show();
 			}
 
 			@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -287,11 +287,10 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		noteEdit.setOnFocusChangeListener((v, hasFocus)->{
 			if(hasFocus){
 				hideFab();
-				noteEdit.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
-			}else{
-				showFab();
-				savePrivateNote(noteEdit.getText().toString());
+				return;
 			}
+			showFab();
+			savePrivateNote(noteEdit.getText().toString());
 		});
 
 		FrameLayout sizeWrapper=new FrameLayout(getActivity()){

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -16,6 +16,7 @@
     <string name="mo_settings_app_version" translatable="false">Moshidon v%1$s (%2$d)</string>
 
     <string name="mo_personal_note">Add a note about this profile</string>
+	<string name="mo_personal_note_saved">Note saved</string>
     <string name="mo_personal_note_confirm">Confirm changes to note</string>
     <string name="mo_personal_note_update_failed">Failed to save note</string>
     <string name="mo_settings_contribute">Contribute to Moshidon</string>


### PR DESCRIPTION
It can be quite unclear if the note has been saved. This adds a toast, to indicate that the profile note has been saved.

On a sidenote, saving currently does not work when pressing the back button, though this should be solved when merging upstream.