### PR TITLE
fix(StatusDisplayItem): check if account is null before adding quote

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/StatusDisplayItem.java
@@ -341,7 +341,7 @@ public abstract class StatusDisplayItem{
 				if(!statusForContent.mediaAttachments.isEmpty() && statusForContent.poll==null) // add spacing if immediately preceded by attachment
 					contentItems.add(new DummyStatusDisplayItem(parentID, fragment));
 				contentItems.addAll(buildItems(fragment, statusForContent.quote, accountID, parentObject, knownAccounts, filterContext, FLAG_NO_FOOTER|FLAG_INSET|FLAG_NO_EMOJI_REACTIONS|FLAG_IS_FOR_QUOTE));
-			} else if((flags & FLAG_INSET)==0 && statusForContent.mediaAttachments.isEmpty()){
+			} else if((flags & FLAG_INSET)==0 && statusForContent.mediaAttachments.isEmpty() && statusForContent.account!=null){
 				tryAddNonOfficialQuote(statusForContent, fragment, accountID, filterContext);
 			}
 			if(contentItems!=items && statusForContent.spoilerRevealed){
@@ -431,6 +431,7 @@ public abstract class StatusDisplayItem{
 			return;
 		String quoteURL=matcher.group();
 
+		// account may be null for scheduled posts
 		if (!UiUtils.looksLikeFediverseUrl(quoteURL))
 			return;
 


### PR DESCRIPTION
This fixes crashes in the ScheduledStatusListFragment, as ScheduledStatus do not contain an account (nor are they able to display quotes, but this catches both).