### PR TITLE
feat(Timeline/Hashtag): show confirmation sheet when muting

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -34,6 +34,7 @@ import org.joinmastodon.android.model.FilterKeyword;
 import org.joinmastodon.android.model.Hashtag;
 import org.joinmastodon.android.model.Status;
 import org.joinmastodon.android.model.TimelineDefinition;
+import org.joinmastodon.android.ui.Snackbar;
 import org.joinmastodon.android.ui.sheets.MuteHashtagConfirmationSheet;
 import org.joinmastodon.android.ui.text.SpacerSpan;
 import org.joinmastodon.android.ui.utils.UiUtils;
@@ -131,6 +132,7 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment{
 			}).exec(accountID);
 		}).show();
 	}
+
 	private void unmuteHashtag() {
 		//safe to get, this only called if filter is present
 		new DeleteFilter(filter.get().id).setCallback(new Callback<>(){
@@ -138,6 +140,9 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment{
 			public void onSuccess(Void result){
 				filter=Optional.empty();
 				updateMuteState(false);
+				new Snackbar.Builder(getContext())
+						.setText(getContext().getString(R.string.unmuted_user_x, '#'+hashtagName))
+						.show();
 			}
 
 			@Override

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
@@ -1,17 +1,13 @@
 package org.joinmastodon.android.ui.sheets;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.view.View;
-import android.widget.Button;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.model.Account;
-import org.joinmastodon.android.ui.M3AlertDialogBuilder;
 import org.joinmastodon.android.ui.views.M3Switch;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,47 +35,6 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		addRow(R.drawable.ic_fluent_alert_off_24_regular, R.string.mo_mute_notifications, m3Switch);
 
 		// add mute duration (Moshidon)
-		Button muteDurationBtn=new Button(getContext());
-		muteDurationBtn.setOnClickListener(v->getMuteDurationDialog(context, muteDuration, muteDurationBtn).show());
-		muteDurationBtn.setText(R.string.sk_duration_indefinite);
-		addRow(R.drawable.ic_fluent_clock_20_regular, R.string.sk_mute_label, muteDurationBtn);
+		addDurationRow(context, muteDuration);
 	}
-
-	@NonNull
-	private M3AlertDialogBuilder getMuteDurationDialog(@NonNull Context context, AtomicReference<Duration> muteDuration, Button button){
-		M3AlertDialogBuilder builder=new M3AlertDialogBuilder(context);
-		builder.setTitle(R.string.sk_mute_label);
-		builder.setIcon(R.drawable.ic_fluent_clock_20_regular);
-		List<Duration> durations =List.of(Duration.ZERO,
-				Duration.ofMinutes(5),
-				Duration.ofMinutes(30),
-				Duration.ofHours(1),
-				Duration.ofHours(6),
-				Duration.ofDays(1),
-				Duration.ofDays(3),
-				Duration.ofDays(7),
-				Duration.ofDays(7));
-
-		String[] choices = {context.getString(R.string.sk_duration_indefinite),
-				context.getString(R.string.sk_duration_minutes_5),
-				context.getString(R.string.sk_duration_minutes_30),
-				context.getString(R.string.sk_duration_hours_1),
-				context.getString(R.string.sk_duration_hours_6),
-				context.getString(R.string.sk_duration_days_1),
-				context.getString(R.string.sk_duration_days_3),
-				context.getString(R.string.sk_duration_days_7)};
-
-		builder.setSingleChoiceItems(choices, durations.indexOf(muteDuration.get()), (dialog, which) -> {});
-
-		builder.setPositiveButton(R.string.ok, (dialog, which)->{
-			int selected = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
-			muteDuration.set(durations.get(selected));
-			button.setText(choices[selected]);
-		});
-		builder.setNegativeButton(R.string.cancel, null);
-
-		return builder;
-	}
-
-
 }

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteHashtagConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteHashtagConfirmationSheet.java
@@ -1,0 +1,30 @@
+package org.joinmastodon.android.ui.sheets;
+
+import android.content.Context;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+import org.joinmastodon.android.R;
+import org.joinmastodon.android.model.Account;
+import org.joinmastodon.android.model.Hashtag;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+// MOSHIDON
+public class MuteHashtagConfirmationSheet extends AccountRestrictionConfirmationSheet{
+	public MuteHashtagConfirmationSheet(@NonNull Context context, Account user, AtomicReference<Duration> muteDuration, Hashtag hashtag, ConfirmCallback confirmCallback){
+		super(context, user, confirmCallback);
+		titleView.setText(R.string.mo_mute_hashtag);
+		confirmBtn.setText(R.string.do_mute);
+		secondaryBtn.setVisibility(View.GONE);
+		icon.setImageResource(R.drawable.ic_fluent_speaker_off_24_regular);
+		subtitleView.setText("#"+hashtag.name);
+		addRow(R.drawable.ic_fluent_number_symbol_24_regular, R.string.mo_mute_hashtag_explanation_muted_home);
+		addRow(R.drawable.ic_fluent_eye_off_24_regular, R.string.mo_mute_hashtag_explanation_discreet);
+		addRow(R.drawable.ic_fluent_search_24_regular, R.string.mo_mute_hashtag_explanation_search);
+		addDurationRow(context, muteDuration);
+	}
+}

--- a/mastodon/src/main/res/values/strings_mo.xml
+++ b/mastodon/src/main/res/values/strings_mo.xml
@@ -45,6 +45,9 @@
 	<string name="mo_confirm_to_mute_conversation">Are you sure you want to mute this conversation?</string>
 	<string name="mo_confirm_to_unmute_conversation">Are you sure you want to unmute this conversation?</string>
 	<string name="mo_mute_hashtag">Mute hashtag</string>
+	<string name="mo_mute_hashtag_explanation_muted_home">You won’t see posts mentioning this hashtag in your Home timeline.</string>
+	<string name="mo_mute_hashtag_explanation_discreet">Others won’t know that you’ve muted this hashtag.</string>
+	<string name="mo_mute_hashtag_explanation_search">You can still find posts with this hashtag on other timelines or through search.</string>
 	<string name="mo_unmute_hashtag">Unmute hashtag</string>
 	<string name="mo_confirm_to_mute_hashtag">Are you sure you want to mute this hashtag?</string>
 	<string name="mo_confirm_to_unmute_hashtag">Are you sure you want to unmute this hashtag?</string>


### PR DESCRIPTION
Shows a MuteHashtagConfirmationSheet when muting a hashtag, similar to the MuteAccountConfirmationSheet. The sheet contains a new duration option, which will let the mute expire after the chosen duration.
Also adds a snackbar for when a hashtag is successfully unmuted.


![Mute hashtag confirmation sheet](https://github.com/user-attachments/assets/ce20a20e-a25d-4338-a5f3-d9c49ae2e5e3)
