### PR TITLE
Feat/block domain

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ProfileFragment.java
@@ -877,7 +877,7 @@ public class ProfileFragment extends LoaderFragment implements OnBackPressedList
 		}else if(id==R.id.open_in_browser){
 			UiUtils.launchWebBrowser(getActivity(), account.url);
 		}else if(id==R.id.block_domain){
-			UiUtils.confirmToggleBlockDomain(getActivity(), accountID, account.getDomain(), relationship.domainBlocking, ()->{
+			UiUtils.confirmToggleBlockDomain(getActivity(), accountID, account, relationship.domainBlocking, ()->{
 				relationship.domainBlocking=!relationship.domainBlocking;
 				updateRelationship();
 			});

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/HeaderStatusDisplayItem.java
@@ -279,7 +279,7 @@ public class HeaderStatusDisplayItem extends StatusDisplayItem{
 						Toast.makeText(activity, activity.getString(rel.following ? R.string.followed_user : rel.requested ? R.string.following_user_requested : R.string.unfollowed_user, account.getDisplayUsername()), Toast.LENGTH_SHORT).show();
 					});
 				}else if(id==R.id.block_domain){
-					UiUtils.confirmToggleBlockDomain(activity, item.parentFragment.getAccountID(), account.getDomain(), relationship!=null && relationship.domainBlocking, ()->{});
+					UiUtils.confirmToggleBlockDomain(activity, item.parentFragment.getAccountID(), account, relationship!=null && relationship.domainBlocking, ()->{});
 				}else if(id==R.id.bookmark){
 					AccountSessionManager.getInstance().getAccount(item.accountID).getStatusInteractionController().setBookmarked(item.status, !item.status.bookmarked);
 				}else if(id==R.id.manage_user_lists){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/BlockDomainConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/BlockDomainConfirmationSheet.java
@@ -1,0 +1,36 @@
+package org.joinmastodon.android.ui.sheets;
+
+import android.content.Context;
+import android.view.View;
+
+import org.joinmastodon.android.R;
+import org.joinmastodon.android.model.Account;
+
+import androidx.annotation.NonNull;
+
+public class BlockDomainConfirmationSheet extends AccountRestrictionConfirmationSheet{
+	public BlockDomainConfirmationSheet(@NonNull Context context, Account user, ConfirmCallback confirmCallback, ConfirmCallback blockUserConfirmCallback){
+		super(context, user, confirmCallback);
+		titleView.setText(R.string.block_domain_confirm_title);
+		confirmBtn.setText(R.string.do_block_server);
+		secondaryBtn.setText(context.getString(R.string.block_user_x_instead, user.getDisplayUsername()));
+		icon.setImageResource(R.drawable.ic_fluent_shield_24_regular);
+		subtitleView.setText(user.getDomain());
+		addRow(R.drawable.ic_campaign_24px, R.string.users_cant_see_blocked);
+		addRow(R.drawable.ic_fluent_eye_off_24_regular, R.string.you_wont_see_server_posts);
+		addRow(R.drawable.ic_fluent_person_delete_24_regular, R.string.server_followers_will_be_removed);
+		addRow(R.drawable.ic_fluent_arrow_reply_24_regular, R.string.server_cant_mention_or_follow_you);
+		addRow(R.drawable.ic_fluent_history_24_regular, R.string.server_can_interact_with_older);
+
+		secondaryBtn.setOnClickListener(v->{
+			if(loading)
+				return;
+			loading=true;
+			secondaryBtn.setProgressBarVisible(true);
+			blockUserConfirmCallback.onConfirmed(this::dismiss, ()->{
+				secondaryBtn.setProgressBarVisible(false);
+				loading=false;
+			});
+		});
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
@@ -2,14 +2,8 @@ package org.joinmastodon.android.ui.sheets;
 
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.graphics.Typeface;
-import android.view.Gravity;
 import android.view.View;
 import android.widget.Button;
-import android.widget.PopupMenu;
-import android.widget.TextView;
-import android.widget.Toast;
 
 import org.joinmastodon.android.R;
 import org.joinmastodon.android.model.Account;
@@ -17,6 +11,7 @@ import org.joinmastodon.android.ui.M3AlertDialogBuilder;
 import org.joinmastodon.android.ui.views.M3Switch;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -47,7 +42,6 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		Button muteDurationBtn=new Button(getContext());
 		muteDurationBtn.setOnClickListener(v->getMuteDurationDialog(context, muteDuration, muteDurationBtn).show());
 		muteDurationBtn.setText(R.string.sk_duration_indefinite);
-
 		addRow(R.drawable.ic_fluent_clock_20_regular, R.string.sk_mute_label, muteDurationBtn);
 	}
 
@@ -56,6 +50,15 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		M3AlertDialogBuilder builder=new M3AlertDialogBuilder(context);
 		builder.setTitle(R.string.sk_mute_label);
 		builder.setIcon(R.drawable.ic_fluent_clock_20_regular);
+		List<Duration> durations =List.of(Duration.ZERO,
+				Duration.ofMinutes(5),
+				Duration.ofMinutes(30),
+				Duration.ofHours(1),
+				Duration.ofHours(6),
+				Duration.ofDays(1),
+				Duration.ofDays(3),
+				Duration.ofDays(7),
+				Duration.ofDays(7));
 
 		String[] choices = {context.getString(R.string.sk_duration_indefinite),
 				context.getString(R.string.sk_duration_minutes_5),
@@ -66,35 +69,14 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 				context.getString(R.string.sk_duration_days_3),
 				context.getString(R.string.sk_duration_days_7)};
 
-		builder.setSingleChoiceItems(choices, 0, (dialog, which) -> {});
+		builder.setSingleChoiceItems(choices, durations.indexOf(muteDuration.get()), (dialog, which) -> {});
 
 		builder.setPositiveButton(R.string.ok, (dialog, which)->{
 			int selected = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
-			if(selected==0){
-				muteDuration.set(Duration.ZERO);
-			}else if(selected==1){
-				muteDuration.set(Duration.ofMinutes(5));
-			}else if(selected==2){
-				muteDuration.set(Duration.ofMinutes(30));
-			}else if(selected==3){
-				muteDuration.set(Duration.ofHours(1));
-			}else if(selected==4){
-				muteDuration.set(Duration.ofHours(6));
-			}else if(selected==5){
-				muteDuration.set(Duration.ofDays(1));
-			}else if(selected==6){
-				muteDuration.set(Duration.ofDays(3));
-			}else if(selected==7){
-				muteDuration.set(Duration.ofDays(7));
-			}
-			if(selected >= 0 && selected <= 7){
-				button.setText(choices[selected]);
-			} else {
-				Toast.makeText(context, "" + selected, Toast.LENGTH_SHORT).show();
-			}
+			muteDuration.set(durations.get(selected));
+			button.setText(choices[selected]);
 		});
-
-		builder.setNegativeButton(R.string.cancel, ((dialogInterface, i) -> {}));
+		builder.setNegativeButton(R.string.cancel, null);
 
 		return builder;
 	}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/sheets/MuteAccountConfirmationSheet.java
@@ -44,10 +44,11 @@ public class MuteAccountConfirmationSheet extends AccountRestrictionConfirmation
 		addRow(R.drawable.ic_fluent_alert_off_24_regular, R.string.mo_mute_notifications, m3Switch);
 
 		// add mute duration (Moshidon)
-		secondaryBtn.setVisibility(View.VISIBLE);
-		secondaryBtn.setOnClickListener(v->getMuteDurationDialog(context, muteDuration, secondaryBtn).show());
-		secondaryBtn.setText(R.string.sk_duration_indefinite);
-		secondaryBtn.setTypeface(null, Typeface.BOLD_ITALIC);
+		Button muteDurationBtn=new Button(getContext());
+		muteDurationBtn.setOnClickListener(v->getMuteDurationDialog(context, muteDuration, muteDurationBtn).show());
+		muteDurationBtn.setText(R.string.sk_duration_indefinite);
+
+		addRow(R.drawable.ic_fluent_clock_20_regular, R.string.sk_mute_label, muteDurationBtn);
 	}
 
 	@NonNull

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/utils/UiUtils.java
@@ -123,6 +123,7 @@ import org.joinmastodon.android.ui.Snackbar;
 import org.joinmastodon.android.ui.sheets.AccountSwitcherSheet;
 import org.joinmastodon.android.ui.sheets.BlockAccountConfirmationSheet;
 import org.joinmastodon.android.ui.sheets.MuteAccountConfirmationSheet;
+import org.joinmastodon.android.ui.sheets.BlockDomainConfirmationSheet;
 import org.joinmastodon.android.ui.text.CustomEmojiSpan;
 import org.joinmastodon.android.ui.text.HtmlParser;
 import org.joinmastodon.android.utils.Tracking;
@@ -574,27 +575,61 @@ public class UiUtils {
 		);
 	}
 
-	public static void confirmToggleBlockDomain(Activity activity, String accountID, String domain, boolean currentlyBlocked, Runnable resultCallback) {
-		showConfirmationAlert(activity, activity.getString(currentlyBlocked ? R.string.confirm_unblock_domain_title : R.string.confirm_block_domain_title),
-				activity.getString(currentlyBlocked ? R.string.confirm_unblock : R.string.confirm_block, domain),
-				activity.getString(currentlyBlocked ? R.string.do_unblock : R.string.do_block),
-				R.drawable.ic_fluent_shield_28_regular,
-				() -> {
-					new SetDomainBlocked(domain, !currentlyBlocked)
-							.setCallback(new Callback<>() {
-								@Override
-								public void onSuccess(Object result) {
-									resultCallback.run();
-								}
+	public static void confirmToggleBlockDomain(Activity activity, String accountID, Account account, boolean currentlyBlocked, Runnable resultCallback){
+		if(!currentlyBlocked){
+			new BlockDomainConfirmationSheet(activity, account, (onSuccess, onError)->{
+				new SetDomainBlocked(account.getDomain(), true)
+						.setCallback(new Callback<>(){
+							@Override
+							public void onSuccess(Object result){
+								resultCallback.run();
+								onSuccess.run();
+							}
 
-								@Override
-								public void onError(ErrorResponse error) {
-									error.showToast(activity);
-								}
-							})
-							.wrapProgress(activity, R.string.loading, false)
-							.exec(accountID);
-				});
+							@Override
+							public void onError(ErrorResponse error){
+								error.showToast(activity);
+								onError.run();
+							}
+						})
+						.exec(accountID);
+			}, (onSuccess, onError)->{
+				new SetAccountBlocked(account.id, true)
+						.setCallback(new Callback<>(){
+							@Override
+							public void onSuccess(Relationship result){
+								resultCallback.run();
+								onSuccess.run();
+								E.post(new RemoveAccountPostsEvent(accountID, account.id, false));
+							}
+
+							@Override
+							public void onError(ErrorResponse error){
+								error.showToast(activity);
+								onError.run();
+							}
+						})
+						.exec(accountID);
+			}).show();
+		}else{
+			new SetDomainBlocked(account.getDomain(), false)
+					.setCallback(new Callback<>(){
+						@Override
+						public void onSuccess(Object result){
+							resultCallback.run();
+							new Snackbar.Builder(activity)
+									.setText(activity.getString(R.string.unblocked_domain_x, account.getDomain()))
+									.show();
+						}
+
+						@Override
+						public void onError(ErrorResponse error){
+							error.showToast(activity);
+						}
+					})
+					.wrapProgress(activity, R.string.loading, false)
+					.exec(accountID);
+		}
 	}
 	public static void confirmToggleMuteUser(Context context, String accountID, Account account, boolean currentlyMuted, Consumer<Relationship> resultCallback){
 		if(!currentlyMuted){

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/viewholders/AccountViewHolder.java
@@ -312,7 +312,7 @@ public class AccountViewHolder extends BindableViewHolder<AccountViewModel> impl
 		}else if(id==R.id.open_in_browser){
 			UiUtils.launchWebBrowser(fragment.getActivity(), account.url);
 		}else if(id==R.id.block_domain){
-			UiUtils.confirmToggleBlockDomain(fragment.getActivity(), accountID, account.getDomain(), relationship.domainBlocking, ()->{
+			UiUtils.confirmToggleBlockDomain(fragment.getActivity(), accountID, account, relationship.domainBlocking, ()->{
 				relationship.domainBlocking=!relationship.domainBlocking;
 				bindRelationship();
 			});


### PR DESCRIPTION
Cherry-picks the `BlockDomainConfirmationSheet` from https://github.com/mastodon/mastodon-android/commit/ad2ef39ace4bf8b6f995b32267289f1a65288b17, as it was apparently missed when merging.

![BlockDomainConfirmationSheet](https://github.com/user-attachments/assets/9ed6cd94-2bb7-4327-ba85-974d0ada7dfe)
