### PR TITLE
feat(Error): disable clicking + crash fix

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ErrorStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/ErrorStatusDisplayItem.java
@@ -40,6 +40,16 @@ public class ErrorStatusDisplayItem extends StatusDisplayItem{
 		}
 
 		@Override
+		public void onClick(){
+			// explicitly do nothing when clicked
+		}
+
+		@Override
+		public boolean isEnabled(){
+			return false;
+		}
+
+		@Override
 		public void onBind(ErrorStatusDisplayItem item) {
 			openInBrowserButton.setEnabled(item.status!=null && item.status.url!=null);
 		}

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/text/HtmlParser.java
@@ -140,7 +140,7 @@ public class HtmlParser{
 							String href=el.attr("href");
 							LinkSpan.Type linkType;
 							String text=el.text();
-							if(el.hasClass("hashtag") || text.startsWith("#")){
+							if(!TextUtils.isEmpty(text) && (el.hasClass("hashtag") || text.startsWith("#"))){
 								// MOSHIDON: we have slightly refactored this so that the hashtags properly work in akkoma
 								// TODO: upstream this
 								linkType=LinkSpan.Type.HASHTAG;


### PR DESCRIPTION
Disables clicking the ErrorStatusDisplayItem, since there is no valid content to be displayed.

Also fixes an issue, where non-mastodon posts could have hashtags without any text, which could lead to an oob String access, e.g.:
https://mastodon.social/@info@hamishcampbell.com/113050670800313268