### PR TITLE
fix(AccountSession): load custom emoji with auth from GTS

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -399,7 +399,7 @@ public class AccountSessionManager{
 	}
 
 	private void updateInstanceEmojis(Instance instance, String domain){
-		new GetCustomEmojis()
+		GetCustomEmojis req=(GetCustomEmojis) new GetCustomEmojis()
 				.setCallback(new Callback<>(){
 					@Override
 					public void onSuccess(List<Emoji> result){
@@ -419,8 +419,14 @@ public class AccountSessionManager{
 						wrapper.instance = instance;
 						MastodonAPIController.runInBackground(()->writeInstanceInfoFile(wrapper, domain));
 					}
-				})
-				.execNoAuth(domain);
+				});
+		if(instance.isGoToSocial()) {
+			// GTS requires auth for emojis
+			// https://github.com/superseriousbusiness/gotosocial/issues/2794
+			req.exec(lastActiveAccountID);
+			return;
+		}
+		req.execNoAuth(domain);
 	}
 
 	private File getInstanceInfoFile(String domain){

--- a/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/model/Instance.java
@@ -1,6 +1,7 @@
 package org.joinmastodon.android.model;
 
 import android.text.Html;
+import android.text.TextUtils;
 import android.util.Log;
 
 import org.joinmastodon.android.api.ObjectValidationException;
@@ -91,6 +92,13 @@ public class Instance extends BaseModel{
 
 	public PleromaPollLimits pollLimits;
 
+	/**
+	 * Url to the source code of the instance.
+	 *
+	 * Only found on GoToSocial instances
+	 */
+	public String sourceUrl;
+
 	/** like uri, but always without scheme and trailing slash */
 	public transient String normalizedUri;
 
@@ -152,6 +160,13 @@ public class Instance extends BaseModel{
 
 	public boolean isPixelfed() {
 		return version.contains("compatible; Pixelfed");
+	}
+
+	/**
+	 * @return `true` if the instance is a GoToSocial instance
+	 */
+	public boolean isGoToSocial() {
+		return TextUtils.equals(sourceUrl, "https://github.com/superseriousbusiness/gotosocial");
 	}
 
 	public boolean hasFeature(Feature feature) {


### PR DESCRIPTION
GoToSocial requires authentication for requesting the emoji list.

Closes https://github.com/sk22/megalodon/issues/989

Since I don't have a GTS account, I was unable to verify if this works.