### PR TITLE
fix(Timeline/Hashtag): check if hashtag is null

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/HashtagTimelineFragment.java
@@ -295,7 +295,7 @@ public class HashtagTimelineFragment extends PinnableStatusListFragment{
 		followMenuItem=optionsMenu.findItem(R.id.follow_hashtag);
 		pinMenuItem=optionsMenu.findItem(R.id.pin);
 		followMenuItem.setVisible(toolbarContentVisible);
-		updateFollowState(hashtag.following);
+		updateFollowState(hashtag!=null && hashtag.following);
 //		pinMenuItem.setShowAsAction(toolbarContentVisible ? MenuItem.SHOW_AS_ACTION_NEVER : MenuItem.SHOW_AS_ACTION_ALWAYS);
 		super.updatePinButton(pinMenuItem);
 


### PR DESCRIPTION
Fixes a crash when clicking on hashtags in profiles, since the hashtag is for some reason null.