### PR TITLE
feat(Compose): exclude own account from reblog mentions

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/ComposeFragment.java
@@ -787,7 +787,7 @@ public class ComposeFragment extends MastodonToolbarFragment implements OnBackPr
 			String ownID=AccountSessionManager.getInstance().getAccount(accountID).self.id;
 			if(!status.account.id.equals(ownID))
 				mentions.add('@'+status.account.acct);
-			if(status.rebloggedBy != null && GlobalUserPreferences.mentionRebloggerAutomatically)
+			if(GlobalUserPreferences.mentionRebloggerAutomatically && status.rebloggedBy != null && !status.rebloggedBy.id.equals(ownID))
 				mentions.add('@'+status.rebloggedBy.acct);
 			for(Mention mention:status.mentions){
 				if(mention.id.equals(ownID))


### PR DESCRIPTION
Excludes the users account from being automatically included when repplying to a status that has been bosted by the user.

Fixes https://github.com/LucasGGamerM/moshidon/issues/548