### PR TITLE
Upgrade build dependencies for the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-	id("com.android.application") version("8.7.2") apply(false)
+	id("com.android.application") version "8.7.2" apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-	repositories {
-		google()
-		mavenCentral()
-		maven {
-			url "https://www.jitpack.io"
-			content {
-				includeModule 'com.github.UnifiedPush', 'android-connector'
-			}
-		}
-		mavenLocal()
-	}
-	dependencies {
-		classpath 'com.android.tools.build:gradle:8.0.0'
-		// NOTE: Do not place your application dependencies here; they belong
-		// in the individual module build.gradle files
-	}
-}
-
-task clean(type: Delete) {
-	delete rootProject.buildDir
+plugins {
+	id("com.android.application") version("8.7.2") apply(false)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=false
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false
 org.gradle.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=false
-android.nonTransitiveRClass=true
 android.nonFinalResIds=false
 org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionSha256Sum=57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,16 @@
+pluginManagement {
+	repositories {
+		google()
+		mavenCentral()
+		maven {
+			url "https://www.jitpack.io"
+			content {
+				includeModule 'com.github.UnifiedPush', 'android-connector'
+			}
+		}
+		mavenLocal()
+	}
+}
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	repositories {


### PR DESCRIPTION
- Upgrade to Gradle 8.11
- Upgrade to Android Gradle Plugin 8.7.2
- Remove deprecated android.defaults.buildfeatures.buildconfig=true gradle property, it is not needed as mastodon/build.gradle already sets android { buildFeatures { buildConfig true } }
- Move plugin repository definition to settings.gradle to match latest Gradle practices
- Move to using plugin {} mechanism to add Android Gradle Plugin to match the latest Gradle practices
- Remove root project clean task as this project does not produce any real artifacts, it seems to be leftover from original Android new project template