### PR TITLE
Delay loading of emojis until emoji picker is opened #2

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/ui/CustomEmojiPopupKeyboard.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/CustomEmojiPopupKeyboard.java
@@ -111,12 +111,13 @@ public class CustomEmojiPopupKeyboard extends PopupKeyboard{
 		list.setPadding(V.dp(16), 0, V.dp(16), 0);
 		imgLoader=new ListImageLoaderWrapper(activity, list, new RecyclerViewDelegate(list), null);
 
-		List<Emoji> recentEmoji=new ArrayList<>(lp.recentCustomEmoji);
-		if(!recentEmoji.isEmpty())
-			adapter.addAdapter(new SingleCategoryAdapter(recentEmojiCategory=new EmojiCategory(activity.getString(R.string.mo_emoji_recent), recentEmoji)));
-
-		for(EmojiCategory category:emojis)
-			adapter.addAdapter(new SingleCategoryAdapter(category));
+		if (!forReaction){
+			List<Emoji> recentEmoji=new ArrayList<>(lp.recentCustomEmoji);
+			if(!recentEmoji.isEmpty())
+				adapter.addAdapter(new SingleCategoryAdapter(recentEmojiCategory=new EmojiCategory(activity.getString(R.string.mo_emoji_recent), recentEmoji)));
+			for(EmojiCategory category : emojis)
+				adapter.addAdapter(new SingleCategoryAdapter(category));
+		}
 		list.setAdapter(adapter);
 		list.addItemDecoration(new RecyclerView.ItemDecoration(){
 			@Override
@@ -227,6 +228,15 @@ public class CustomEmojiPopupKeyboard extends PopupKeyboard{
 			emojis=AccountSessionManager.getInstance().getCustomEmojis(domain);
 			adapter.notifyDataSetChanged();
 		}
+	}
+
+	public void customToggleKeyboardPopup(){
+		List<Emoji> recentEmoji=new ArrayList<>(lp.recentCustomEmoji);
+		if(!recentEmoji.isEmpty())
+			adapter.addAdapter(new SingleCategoryAdapter(recentEmojiCategory=new EmojiCategory(activity.getString(R.string.mo_emoji_recent), recentEmoji)));
+		for(EmojiCategory category : emojis)
+			adapter.addAdapter(new SingleCategoryAdapter(category));
+		super.toggleKeyboardPopup(null);
 	}
 
 	private class SingleCategoryAdapter extends UsableRecyclerView.Adapter<RecyclerView.ViewHolder> implements ImageLoaderRecyclerAdapter, Filterable{

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/CustomEmojiPopupKeyboard.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/CustomEmojiPopupKeyboard.java
@@ -231,11 +231,13 @@ public class CustomEmojiPopupKeyboard extends PopupKeyboard{
 	}
 
 	public void customToggleKeyboardPopup(){
-		List<Emoji> recentEmoji=new ArrayList<>(lp.recentCustomEmoji);
-		if(!recentEmoji.isEmpty())
-			adapter.addAdapter(new SingleCategoryAdapter(recentEmojiCategory=new EmojiCategory(activity.getString(R.string.mo_emoji_recent), recentEmoji)));
-		for(EmojiCategory category : emojis)
-			adapter.addAdapter(new SingleCategoryAdapter(category));
+		if (adapter.getAdapterCount() == 0){
+			List<Emoji> recentEmoji=new ArrayList<>(lp.recentCustomEmoji);
+			if(!recentEmoji.isEmpty())
+				adapter.addAdapter(new SingleCategoryAdapter(recentEmojiCategory=new EmojiCategory(activity.getString(R.string.mo_emoji_recent), recentEmoji)));
+			for(EmojiCategory category : emojis)
+				adapter.addAdapter(new SingleCategoryAdapter(category));
+		}
 		super.toggleKeyboardPopup(null);
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/EmojiReactionsStatusDisplayItem.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/ui/displayitems/EmojiReactionsStatusDisplayItem.java
@@ -265,7 +265,7 @@ public class EmojiReactionsStatusDisplayItem extends StatusDisplayItem {
 		public void onBackspace() {}
 
 		private void onReactClick(View v){
-			emojiKeyboard.toggleKeyboardPopup(null);
+			emojiKeyboard.customToggleKeyboardPopup();
 			v.setSelected(emojiKeyboard.isVisible());
 			space.setVisibility(emojiKeyboard.isVisible() ? View.VISIBLE : View.GONE);
 			DisplayMetrics displayMetrics = new DisplayMetrics();


### PR DESCRIPTION
Fixes https://github.com/LucasGGamerM/moshidon/issues/559

Loading emojis after clicking the emoji keyboard should be soon enough.
The whole emoji keyboard loading for every react button leads to ooms.