### PR TITLE
Standard push + UnifiedPush update

### DIFF
--- a/mastodon/build.gradle
+++ b/mastodon/build.gradle
@@ -164,7 +164,7 @@ dependencies {
 	implementation 'com.github.bottom-software-foundation:bottom-java:2.1.0'
 	annotationProcessor 'org.parceler:parceler:1.1.12'
 	coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
-	implementation 'com.github.UnifiedPush:android-connector:2.1.1'
+	implementation 'org.unifiedpush.android:connector:3.0.2'
 
 	androidTestImplementation 'androidx.test:core:1.5.0'
 	androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/mastodon/src/main/java/org/joinmastodon/android/MastodonApp.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/MastodonApp.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.webkit.WebView;
 
 import org.joinmastodon.android.api.PushSubscriptionManager;
+import org.joinmastodon.android.utils.UnifiedPushHelper;
 
 import me.grishka.appkit.imageloader.ImageCache;
 import me.grishka.appkit.utils.NetworkUtils;
@@ -27,7 +28,11 @@ public class MastodonApp extends Application{
 		ImageCache.setParams(params);
 		NetworkUtils.setUserAgent("MoshidonAndroid/"+BuildConfig.VERSION_NAME);
 
-		PushSubscriptionManager.tryRegisterFCM();
+		if (UnifiedPushHelper.isUnifiedPushEnabled(this)){
+			UnifiedPushHelper.registerAllAccounts(this);
+		} else {
+			PushSubscriptionManager.tryRegisterFCM();
+		}
 		GlobalUserPreferences.load();
 		if(BuildConfig.DEBUG){
 			WebView.setWebContentsDebuggingEnabled(true);

--- a/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/PushNotificationReceiver.java
@@ -163,7 +163,7 @@ public class PushNotificationReceiver extends BroadcastReceiver{
 		PushNotificationReceiver.this.notify(context, PushNotification.fromNotification(context, account, notification), account.getID(), notification);
 	}
 
-	private void notify(Context context, PushNotification pn, String accountID, org.joinmastodon.android.model.Notification notification){
+	void notify(Context context, PushNotification pn, String accountID, org.joinmastodon.android.model.Notification notification){
 		NotificationManager nm=context.getSystemService(NotificationManager.class);
 		AccountSession session=AccountSessionManager.get(accountID);
 		Account self=session.self;

--- a/mastodon/src/main/java/org/joinmastodon/android/UnifiedPushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/UnifiedPushNotificationReceiver.java
@@ -9,10 +9,14 @@ import org.joinmastodon.android.api.session.AccountSession;
 import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.Notification;
 import org.joinmastodon.android.model.PaginatedResponse;
+import org.unifiedpush.android.connector.FailedReason;
 import org.unifiedpush.android.connector.MessagingReceiver;
+import org.unifiedpush.android.connector.data.PushEndpoint;
+import org.unifiedpush.android.connector.data.PushMessage;
 
 import java.util.List;
 
+import kotlin.text.Charsets;
 import me.grishka.appkit.api.Callback;
 import me.grishka.appkit.api.ErrorResponse;
 
@@ -24,16 +28,16 @@ public class UnifiedPushNotificationReceiver extends MessagingReceiver{
 	}
 
 	@Override
-	public void onNewEndpoint(@NotNull Context context, @NotNull String endpoint, @NotNull String instance) {
+	public void onNewEndpoint(@NotNull Context context, @NotNull PushEndpoint endpoint, @NotNull String instance) {
 		// Called when a new endpoint be used for sending push messages
-		Log.d(TAG, "onNewEndpoint: New Endpoint " + endpoint + " for "+ instance);
+		Log.d(TAG, "onNewEndpoint: New Endpoint " + endpoint.getUrl() + " for "+ instance);
 		AccountSession account = AccountSessionManager.getInstance().tryGetAccount(instance);
 		if (account != null)
-			account.getPushSubscriptionManager().registerAccountForPush(null, endpoint);
+			account.getPushSubscriptionManager().registerAccountForPush(null, endpoint.getUrl());
 	}
 
 	@Override
-	public void onRegistrationFailed(@NotNull Context context, @NotNull String instance) {
+	public void onRegistrationFailed(@NotNull Context context, @NotNull FailedReason reason, @NotNull String instance) {
 		// called when the registration is not possible, eg. no network
 		Log.d(TAG, "onRegistrationFailed: " + instance);
 		//re-register for gcm
@@ -53,7 +57,8 @@ public class UnifiedPushNotificationReceiver extends MessagingReceiver{
 	}
 
 	@Override
-	public void onMessage(@NotNull Context context, @NotNull byte[] message, @NotNull String instance) {
+	public void onMessage(@NotNull Context context, @NotNull PushMessage message, @NotNull String instance) {
+		Log.d(TAG, "New message for " + instance);
 		// Called when a new message is received. The message contains the full POST body of the push message
 		AccountSession account = AccountSessionManager.getInstance().tryGetAccount(instance);
 

--- a/mastodon/src/main/java/org/joinmastodon/android/UnifiedPushNotificationReceiver.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/UnifiedPushNotificationReceiver.java
@@ -39,7 +39,7 @@ public class UnifiedPushNotificationReceiver extends MessagingReceiver{
 		if (account != null) {
 			PublicKeySet ks = endpoint.getPubKeySet();
 			if (ks != null){
-				account.getPushSubscriptionManager().registerAccountForPush(null, endpoint.getUrl(), ks.getPubKey(), ks.getAuth());
+				account.getPushSubscriptionManager().registerAccountForPush(null, true, endpoint.getUrl(), ks.getPubKey(), ks.getAuth());
 			} else {
 				// ks should never be null on new endpoint
 				account.getPushSubscriptionManager().registerAccountForPush(null, endpoint.getUrl());

--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -166,17 +166,21 @@ public class PushSubscriptionManager{
 
 			//work-around for adding the randomAccountId
 			String newEndpoint = endpoint;
-			if (endpoint.startsWith("https://app.joinmastodon.org/relay-to/fcm/"))
-				newEndpoint += pushAccountID;
+			Boolean standard = true;
+			if (endpoint.startsWith("https://app.joinmastodon.org/relay-to/fcm/")){
+				newEndpoint+=pushAccountID;
+				standard = false;
+			}
 
-			registerAccountForPush(subscription, newEndpoint, encodedPublicKey, encodedAuthKey);
+			registerAccountForPush(subscription, standard, newEndpoint, encodedPublicKey, encodedAuthKey);
 		});
 	}
 
-	public void registerAccountForPush(PushSubscription subscription, String endpoint, String p256dh, String auth){
+	public void registerAccountForPush(PushSubscription subscription, Boolean standard, String endpoint, String p256dh, String auth){
 		MastodonAPIController.runInBackground(()->{
 			Log.d(TAG, "registerAccountForPush: started for "+accountID);
 			new RegisterForPushNotifications(endpoint,
+					standard,
 					p256dh,
 					auth,
 					subscription==null ? PushSubscription.Alerts.ofAll() : subscription.alerts,

--- a/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/PushSubscriptionManager.java
@@ -169,9 +169,16 @@ public class PushSubscriptionManager{
 			if (endpoint.startsWith("https://app.joinmastodon.org/relay-to/fcm/"))
 				newEndpoint += pushAccountID;
 
-			new RegisterForPushNotifications(newEndpoint,
-					encodedPublicKey,
-					encodedAuthKey,
+			registerAccountForPush(subscription, newEndpoint, encodedPublicKey, encodedAuthKey);
+		});
+	}
+
+	public void registerAccountForPush(PushSubscription subscription, String endpoint, String p256dh, String auth){
+		MastodonAPIController.runInBackground(()->{
+			Log.d(TAG, "registerAccountForPush: started for "+accountID);
+			new RegisterForPushNotifications(endpoint,
+					p256dh,
+					auth,
 					subscription==null ? PushSubscription.Alerts.ofAll() : subscription.alerts,
 					subscription==null ? PushSubscription.Policy.ALL : subscription.policy)
 					.setCallback(new Callback<>(){

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/notifications/RegisterForPushNotifications.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/notifications/RegisterForPushNotifications.java
@@ -4,10 +4,11 @@ import org.joinmastodon.android.api.MastodonAPIRequest;
 import org.joinmastodon.android.model.PushSubscription;
 
 public class RegisterForPushNotifications extends MastodonAPIRequest<PushSubscription>{
-	public RegisterForPushNotifications(String endpoint, String encryptionKey, String authKey, PushSubscription.Alerts alerts, PushSubscription.Policy policy){
+	public RegisterForPushNotifications(String endpoint, Boolean standard, String encryptionKey, String authKey, PushSubscription.Alerts alerts, PushSubscription.Policy policy){
 		super(HttpMethod.POST, "/push/subscription", PushSubscription.class);
 		Request r=new Request();
 		r.subscription.endpoint=endpoint;
+		r.subscription.standard = standard;
 		r.data.alerts=alerts;
 		r.policy=policy;
 		r.subscription.keys.p256dh=encryptionKey;
@@ -28,7 +29,7 @@ public class RegisterForPushNotifications extends MastodonAPIRequest<PushSubscri
 		private static class Subscription{
 			public String endpoint;
 			// Use standard push notifications if available
-			public Boolean standard = true;
+			public Boolean standard;
 			public Keys keys=new Keys();
 		}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/notifications/RegisterForPushNotifications.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/notifications/RegisterForPushNotifications.java
@@ -27,6 +27,8 @@ public class RegisterForPushNotifications extends MastodonAPIRequest<PushSubscri
 
 		private static class Subscription{
 			public String endpoint;
+			// Use standard push notifications if available
+			public Boolean standard = true;
 			public Keys keys=new Keys();
 		}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -133,7 +133,7 @@ public class AccountSessionManager{
 					context,
 					session.getID(),
 					null,
-					null
+					session.app.vapidKey.replaceAll("=","")
 			);
 		} else if(PushSubscriptionManager.arePushNotificationsAvailable()){
 			session.getPushSubscriptionManager().registerAccountForPush(null);

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -127,12 +127,12 @@ public class AccountSessionManager{
 		MastodonAPIController.runInBackground(()->writeInstanceInfoFile(wrapper, instance.uri));
 
 		updateMoreInstanceInfo(instance, instance.uri);
-		if (!UnifiedPush.getDistributor(context).isEmpty()) {
-			UnifiedPush.registerApp(
+		if (UnifiedPush.getAckDistributor(context) != null) {
+			UnifiedPush.register(
 					context,
 					session.getID(),
-					new ArrayList<>(),
-					context.getPackageName()
+					null,
+					null
 			);
 		} else if(PushSubscriptionManager.arePushNotificationsAvailable()){
 			session.getPushSubscriptionManager().registerAccountForPush(null);

--- a/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/session/AccountSessionManager.java
@@ -34,6 +34,7 @@ import org.joinmastodon.android.model.EmojiCategory;
 import org.joinmastodon.android.model.LegacyFilter;
 import org.joinmastodon.android.model.Instance;
 import org.joinmastodon.android.model.Token;
+import org.joinmastodon.android.utils.UnifiedPushHelper;
 import org.unifiedpush.android.connector.UnifiedPush;
 
 import java.io.File;
@@ -127,7 +128,7 @@ public class AccountSessionManager{
 		MastodonAPIController.runInBackground(()->writeInstanceInfoFile(wrapper, instance.uri));
 
 		updateMoreInstanceInfo(instance, instance.uri);
-		if (UnifiedPush.getAckDistributor(context) != null) {
+		if (UnifiedPushHelper.isUnifiedPushEnabled(context)) {
 			UnifiedPush.register(
 					context,
 					session.getID(),

--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/settings/SettingsNotificationsFragment.java
@@ -26,6 +26,7 @@ import org.joinmastodon.android.model.viewmodel.ListItem;
 import org.joinmastodon.android.ui.M3AlertDialogBuilder;
 import org.joinmastodon.android.ui.utils.HideableSingleViewRecyclerAdapter;
 import org.joinmastodon.android.ui.utils.UiUtils;
+import org.joinmastodon.android.utils.UnifiedPushHelper;
 import org.unifiedpush.android.connector.UnifiedPush;
 
 import java.time.Instant;
@@ -57,6 +58,7 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 
 	// MEGALODON
 	private boolean useUnifiedPush = false;
+	private boolean hasAnyUnifiedPushDistrib = false;
 	private CheckableListItem<Void> uniformIconItem, deleteItem, onlyLatestItem, unifiedPushItem;
 	private CheckableListItem<Void> postsItem, updateItem;
 
@@ -72,7 +74,8 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 		lp=AccountSessionManager.get(accountID).getLocalPreferences();
 
 		getPushSubscription();
-		useUnifiedPush=UnifiedPush.getAckDistributor(getContext()) != null;
+		useUnifiedPush=UnifiedPushHelper.isUnifiedPushEnabled(getContext());
+		hasAnyUnifiedPushDistrib=UnifiedPushHelper.hasAnyDistributorInstalled(getContext());
 
 		onDataLoaded(List.of(
 				pauseItem=new CheckableListItem<>(getString(R.string.pause_all_notifications), getPauseItemSubtitle(), CheckableListItem.Style.SWITCH, false, R.drawable.ic_fluent_alert_snooze_24_regular, i->onPauseNotificationsClick(false)),
@@ -94,7 +97,7 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 		));
 
 		//only enable when distributors, who can receive notifications, are available
-		unifiedPushItem.isEnabled=!UnifiedPush.getDistributors(getContext()).isEmpty();
+		unifiedPushItem.isEnabled=hasAnyUnifiedPushDistrib;
 		if (!unifiedPushItem.isEnabled) {
 			unifiedPushItem.subtitleRes=R.string.sk_settings_unifiedpush_no_distributor_body;
 		}
@@ -316,12 +319,12 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 			bannerText.setText(R.string.notifications_disabled_in_system);
 			bannerButton.setText(R.string.open_system_notification_settings);
 			bannerButton.setOnClickListener(v->openSystemNotificationSettings());
-		}else if(BuildConfig.BUILD_TYPE.equals("fdroidRelease") && UnifiedPush.getAckDistributor(getContext()) != null){
+		}else if(BuildConfig.BUILD_TYPE.equals("fdroidRelease") && useUnifiedPush){
 			bannerAdapter.setVisible(true);
 			bannerIcon.setImageResource(R.drawable.ic_fluent_warning_24_filled);
 			bannerTitle.setVisibility(View.VISIBLE);
 			bannerTitle.setText(R.string.mo_settings_unifiedpush_warning);
-			if(UnifiedPush.getDistributors(getContext()).isEmpty()) {
+			if(!hasAnyUnifiedPushDistrib) {
 				bannerText.setText(R.string.mo_settings_unifiedpush_warning_no_distributors);
 				bannerButton.setText(R.string.info);
 				bannerButton.setOnClickListener(v->UiUtils.launchWebBrowser(getContext(), "https://unifiedpush.org/"));
@@ -342,23 +345,15 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 	}
 
 	private void onUnifiedPushClick(){
-		if(UnifiedPush.getAckDistributor(getContext()) == null){
+		if(!useUnifiedPush){
 			List<String> distributors = UnifiedPush.getDistributors(getContext());
 			showUnifiedPushRegisterDialog(distributors);
 			return;
 		}
-
-		for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()) {
-			UnifiedPush.unregister(
-					getContext(),
-					accountSession.getID()
-			);
-
-			//re-register to fcm
-			accountSession.getPushSubscriptionManager().registerAccountForPush(getPushSubscription());
-		}
+		UnifiedPushHelper.unregisterAllAccounts(getContext());
 		unifiedPushItem.toggle();
 		rebindItem(unifiedPushItem);
+		useUnifiedPush = false;
 	}
 
 	private void showUnifiedPushRegisterDialog(List<String> distributors){
@@ -366,16 +361,10 @@ public class SettingsNotificationsFragment extends BaseSettingsFragment<Void>{
 				(dialog, which)->{
 					String userDistrib = distributors.get(which);
 					UnifiedPush.saveDistributor(getContext(), userDistrib);
-					for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()){
-						UnifiedPush.register(
-								getContext(),
-								accountSession.getID(),
-								null,
-								null
-						);
-					}
+					UnifiedPushHelper.registerAllAccounts(getContext());
 					unifiedPushItem.toggle();
 					rebindItem(unifiedPushItem);
+					useUnifiedPush = true;
 				}).setOnCancelListener(d->rebindItem(unifiedPushItem)).show();
 	}
 

--- a/mastodon/src/main/java/org/joinmastodon/android/utils/UnifiedPushHelper.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/UnifiedPushHelper.java
@@ -1,0 +1,51 @@
+package org.joinmastodon.android.utils;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.joinmastodon.android.api.session.AccountSession;
+import org.joinmastodon.android.api.session.AccountSessionManager;
+import org.unifiedpush.android.connector.UnifiedPush;
+
+public class UnifiedPushHelper {
+
+	/**
+	 * @param context
+	 * @return `true` if UnifiedPush is used
+	 */
+	public static boolean isUnifiedPushEnabled(@NonNull Context context) {
+		return UnifiedPush.getAckDistributor(context) != null;
+	}
+
+	/**
+	 * If any distributor is installed on the device
+	 * @param context
+	 * @return `true` if at least one is installed
+	 */
+	public static boolean hasAnyDistributorInstalled(@NonNull Context context) {
+		return !UnifiedPush.getDistributors(context).isEmpty();
+	}
+
+	public static void registerAllAccounts(@NonNull Context context) {
+		for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()){
+			UnifiedPush.register(
+					context,
+					accountSession.getID(),
+					null,
+					null
+			);
+		}
+	}
+
+	public static void unregisterAllAccounts(@NonNull Context context) {
+		for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()){
+			UnifiedPush.unregister(
+					context,
+					accountSession.getID()
+			);
+			// use FCM again
+			accountSession.getPushSubscriptionManager().registerAccountForPush(null);
+		}
+	}
+}

--- a/mastodon/src/main/java/org/joinmastodon/android/utils/UnifiedPushHelper.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/UnifiedPushHelper.java
@@ -33,7 +33,7 @@ public class UnifiedPushHelper {
 					context,
 					accountSession.getID(),
 					null,
-					null
+					accountSession.app.vapidKey.replaceAll("=","")
 			);
 		}
 	}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,12 +2,6 @@ pluginManagement {
 	repositories {
 		google()
 		mavenCentral()
-		maven {
-			url "https://www.jitpack.io"
-			content {
-				includeModule 'com.github.UnifiedPush', 'android-connector'
-			}
-		}
 		mavenLocal()
 	}
 }
@@ -17,7 +11,12 @@ dependencyResolutionManagement {
 		google()
 		mavenCentral()
 		mavenLocal()
-		maven { url 'https://jitpack.io' }
+		maven {
+			url 'https://jitpack.io'
+			content {
+				includeModule 'com.github.bottom-software-foundation', 'bottom-java'
+			}
+		}
 	}
 }
 rootProject.name = "Moshidon"


### PR DESCRIPTION
- UnifiedPush lib version 3.0.0 and above can automatically handle webpush decryption
- Mastodon version 4.4.0 and above [will support standard webpush encryption](https://github.com/mastodon/mastodon/pull/33528)

This PR takes advantage of the 2 previous news to used the content of (decrypted) push notifications with UnifiedPush when it is possible.

For the moment, legacy encryption is still used with FCM, but it is possible to migrate to the standard for FCM too. I will link the PR to the webpush->FCM bridge used when opened.

I've also added another change (on MastodonApp.java). It may have been better to use another PR but this is pretty small change, so I hope it's OK: when opening the application, if the users uses UnifiedPush, we don't register to FCM and we register to UnifiedPush again