### PR TITLE
[#346] Fix Akkoma translations.

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/api/requests/statuses/AkkomaTranslateStatus.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/api/requests/statuses/AkkomaTranslateStatus.java
@@ -5,7 +5,6 @@ import org.joinmastodon.android.model.AkkomaTranslation;
 
 public class AkkomaTranslateStatus extends MastodonAPIRequest<AkkomaTranslation>{
 	public AkkomaTranslateStatus(String id, String lang){
-		super(HttpMethod.GET, "/statuses/"+id+"/translations/"+lang.toUpperCase(), AkkomaTranslation.class);
+		super(HttpMethod.GET, "/statuses/"+id+"/translations/"+lang.toLowerCase(), AkkomaTranslation.class);
 	}
 }
-


### PR DESCRIPTION
Not sure if something has changed in the Akkoma API since the latest version of `AkkomaTranslateStatus`, but it seems that the API expects the target language to be _lowercase_ (not _uppercase_).

Libretranslate nginx traces from my instance with the current implementation show a 400 with the current implementation:

```
1.2.3.4 - - [11/Feb/2025:11:40:34 +0100] "POST /translate HTTP/1.1" 400 32 "-" "Akkoma 3.13.2-0-g050bc74; https://myinstance.social <fabio@myinstance.social>"
```

And that's also mirrored on my Akkoma logs:

```
1.2.3.4 - - [11/Feb/2025:11:40:35 +0100] "GET /api/v1/statuses/Ar0PZaoyJwN2GD3UJs/translations/EN HTTP/2.0" 400 54 "-" "MoshidonAndroid/2.3.0+fork.108.moshinda"
```

A direct API call to the endpoint above indeed returns a 400:

```
{"error":"libre_translate: request failed (code 400)"}
```

But everything works when `en` is used instead of `EN`:

```
{"text":"<p>Help me! </p><p>**As a large organization you go to Mastodon because: **<br/>- You want to set a standard<br/>- Guarantee your free access to your posts<br/>- as an anti-reaction against big tech and its associated:<br/> - data collections<br/> - earning models<br/> - algorithms that spread her<br/>- ... </p><p>**You run your own server because: **<br/>- your owner wants to remain over your dates<br/>- you can arrange your own accounts for your employees<br/>- ...</p><p>What arguments would you have for switching to Mastodon and own server?</p>","detected_language":"nl"}
```

Closes: #346 