### PR TITLE
Fix a NullPointerException in NotificationsListFragment.java

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/fragments/NotificationsListFragment.java
@@ -125,7 +125,7 @@ public class NotificationsListFragment extends BaseStatusListFragment<Notificati
 		NotificationHeaderStatusDisplayItem titleItem;
 		Account self=AccountSessionManager.get(accountID).self;
 		if(n.type==Notification.Type.MENTION || n.type==Notification.Type.STATUS
-				|| (n.type==Notification.Type.REBLOG && n.status.account != null && !n.status.account.id.equals(self.id))){ // Iceshrimp quote
+				|| (n.type==Notification.Type.REBLOG && n.status != null && n.status.account != null && !n.status.account.id.equals(self.id))){ // Iceshrimp quote
 			titleItem=null;
 		}else{
 			titleItem=new NotificationHeaderStatusDisplayItem(n.id, this, n, accountID);


### PR DESCRIPTION
- Some notifications will have the status attribute set as null and the if in 128 is trying to access to attributes from a null object, causing a NPE as soon as the app is opened.