### PR TITLE
Check VAPID key to avoid VapidNotValidException

### DIFF
--- a/mastodon/src/main/java/org/joinmastodon/android/utils/UnifiedPushHelper.java
+++ b/mastodon/src/main/java/org/joinmastodon/android/utils/UnifiedPushHelper.java
@@ -10,6 +10,8 @@ import org.joinmastodon.android.api.session.AccountSessionManager;
 import org.joinmastodon.android.model.PushSubscription;
 import org.unifiedpush.android.connector.UnifiedPush;
 
+import java.util.regex.Pattern;
+
 public class UnifiedPushHelper {
 
 	/**
@@ -33,9 +35,13 @@ public class UnifiedPushHelper {
 		for (AccountSession accountSession : AccountSessionManager.getInstance().getLoggedInAccounts()){
 			String vapidKey = accountSession.app.vapidKey;
 			// Sometimes this is null when the account's server has died (don't ask me how I know this)
-			if (vapidKey == null) {
+
+			Pattern pattern=Pattern.compile("^[A-Za-z0-9_-]{87}=*$");
+			if (vapidKey != null && vapidKey.isEmpty()) {
+				Toast.makeText(context, accountSession.domain + " doesn't support push notifications.", Toast.LENGTH_LONG).show();
+			} else if (vapidKey == null || !pattern.matcher(vapidKey).find()) {
 				// TODO: throw this on a translatable string and tell the user to log out and back in
-				Toast.makeText(context, "Error on unified push subscription: no valid vapid key for account " + accountSession.getFullUsername(), Toast.LENGTH_LONG).show();
+				Toast.makeText(context, "Error on UnifiedPush subscription: no valid vapid key for account " + accountSession.getFullUsername(), Toast.LENGTH_LONG).show();
 				break;
 			}
 			PushSubscription sub = accountSession.pushSubscription;


### PR DESCRIPTION
Some server softwares like [Hollo](https://github.com/fedify-dev/hollo/) return an empty non-null vapid key which lead to a crash. It should inform user instead of crashing

I received this crash report:

```
2.3.0+fork.110.moshinda (110)
2025-11-09T16:51:56.460Z

java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:641)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
	... 1 more
Caused by: org.unifiedpush.android.connector.UnifiedPush$VapidNotValidException
	at org.unifiedpush.android.connector.UnifiedPush.register(UnifiedPush.kt:252)
	at org.unifiedpush.android.connector.UnifiedPush.register(UnifiedPush.kt:228)
	at org.unifiedpush.android.connector.UnifiedPush.register(UnifiedPush.kt:200)
	at org.joinmastodon.android.utils.UnifiedPushHelper.registerAllAccounts(UnifiedPushHelper.java:49)
	at org.joinmastodon.android.fragments.settings.SettingsNotificationsFragment.lambda$showUnifiedPushRegisterDialog$28(SettingsNotificationsFragment.java:367)
	at org.joinmastodon.android.fragments.settings.SettingsNotificationsFragment.$r8$lambda$gvxT_BzhJleOu10rYUVJ1mJv0dk(SettingsNotificationsFragment.java:0)
	at org.joinmastodon.android.fragments.settings.SettingsNotificationsFragment$$ExternalSyntheticLambda19.onClick(R8$$SyntheticClass:0)
	at com.android.internal.app.AlertController$AlertParams$3.onItemClick(AlertController.java:1250)
	at android.widget.AdapterView.performItemClick(AdapterView.java:330)
	at android.widget.AbsListView.performItemClick(AbsListView.java:1210)
	at android.widget.AbsListView$PerformClick.run(AbsListView.java:3202)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:233)
	at android.app.ActivityThread.main(ActivityThread.java:8068)
	... 3 more
```